### PR TITLE
Phase 5: Add CI/CD scripts, deploy workflow, and smoke tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,155 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      aws_region:
+        description: 'AWS Region'
+        required: true
+        default: 'us-east-1'
+      state_bucket_name:
+        description: 'S3 bucket for TF state (auto-generated if empty)'
+        required: false
+        default: ''
+
+env:
+  TF_VAR_aws_region: ${{ inputs.aws_region }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ inputs.aws_region }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.5'
+          terraform_wrapper: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      # Step 1: Bootstrap state bucket
+      - name: Resolve bucket name
+        id: bucket
+        run: |
+          if [ -n "${{ inputs.state_bucket_name }}" ]; then
+            echo "name=${{ inputs.state_bucket_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "name=$(bash scripts/generate_bucket_name.sh)" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Bootstrap state bucket
+        run: |
+          cd infra/00-bootstrap
+          terraform init
+          terraform apply -auto-approve \
+            -var "state_bucket_name=${{ steps.bucket.outputs.name }}" \
+            -var "aws_region=${{ inputs.aws_region }}"
+
+      # Step 2: Create ECR
+      - name: Deploy ECR
+        run: |
+          cd infra/01-ecr
+          bash ../../scripts/generate_backend.sh \
+            "${{ steps.bucket.outputs.name }}" "ecr" "${{ inputs.aws_region }}"
+          terraform init
+          terraform apply -auto-approve \
+            -var "aws_region=${{ inputs.aws_region }}"
+
+      - name: Get ECR repo URL
+        id: ecr
+        run: |
+          cd infra/01-ecr
+          echo "url=$(terraform output -raw ecr_repo_url)" >> $GITHUB_OUTPUT
+
+      # Step 3: Build and push Docker image
+      - name: Login to ECR
+        run: |
+          aws ecr get-login-password --region ${{ inputs.aws_region }} | \
+            docker login --username AWS --password-stdin ${{ steps.ecr.outputs.url }}
+
+      - name: Build and push
+        run: |
+          docker build -f docker/Dockerfile -t ${{ steps.ecr.outputs.url }}:${{ github.sha }} -t ${{ steps.ecr.outputs.url }}:latest .
+          docker push ${{ steps.ecr.outputs.url }}:${{ github.sha }}
+          docker push ${{ steps.ecr.outputs.url }}:latest
+
+      # Step 4: Deploy system
+      - name: Deploy infrastructure
+        run: |
+          cd infra/02-deploy
+          bash ../../scripts/generate_backend.sh \
+            "${{ steps.bucket.outputs.name }}" "deploy" "${{ inputs.aws_region }}"
+          bash ../../scripts/generate_tfvars.sh \
+            "${{ steps.ecr.outputs.url }}" "${{ github.sha }}" "${{ inputs.aws_region }}"
+          terraform init
+          terraform apply -auto-approve
+
+      - name: Get deploy outputs
+        id: deploy
+        run: |
+          cd infra/02-deploy
+          echo "api_url=$(terraform output -raw api_gateway_url)" >> $GITHUB_OUTPUT
+          echo "orders_table=$(terraform output -json dynamodb_table_names | jq -r '.orders')" >> $GITHUB_OUTPUT
+          echo "order_events_table=$(terraform output -json dynamodb_table_names | jq -r '.order_events')" >> $GITHUB_OUTPUT
+          echo "locks_table=$(terraform output -json dynamodb_table_names | jq -r '.orchestrator_locks')" >> $GITHUB_OUTPUT
+          echo "internal_bucket=$(terraform output -json s3_bucket_names | jq -r '.internal')" >> $GITHUB_OUTPUT
+          echo "done_bucket=$(terraform output -json s3_bucket_names | jq -r '.done')" >> $GITHUB_OUTPUT
+
+      # Step 5: Smoke tests
+      - name: Run smoke tests
+        run: |
+          export API_GATEWAY_URL="${{ steps.deploy.outputs.api_url }}"
+          export AWS_REGION="${{ inputs.aws_region }}"
+          export ORDERS_TABLE="${{ steps.deploy.outputs.orders_table }}"
+          export ORDER_EVENTS_TABLE="${{ steps.deploy.outputs.order_events_table }}"
+          export LOCKS_TABLE="${{ steps.deploy.outputs.locks_table }}"
+          export INTERNAL_BUCKET="${{ steps.deploy.outputs.internal_bucket }}"
+          export DONE_BUCKET="${{ steps.deploy.outputs.done_bucket }}"
+          bash tests/smoke/test_deploy.sh
+
+      # Step 6: Archive for teardown
+      - name: Create teardown archive
+        run: |
+          mkdir -p /tmp/teardown/infra/01-ecr
+          mkdir -p /tmp/teardown/infra/02-deploy
+
+          cp infra/01-ecr/*.tf /tmp/teardown/infra/01-ecr/
+          cp infra/01-ecr/backend.tf /tmp/teardown/infra/01-ecr/ 2>/dev/null || true
+
+          cp infra/02-deploy/*.tf /tmp/teardown/infra/02-deploy/
+          cp infra/02-deploy/backend.tf /tmp/teardown/infra/02-deploy/ 2>/dev/null || true
+          cp infra/02-deploy/terraform.tfvars /tmp/teardown/infra/02-deploy/ 2>/dev/null || true
+
+          cat > /tmp/teardown/TEARDOWN.md << 'TDEOF'
+          # Teardown Instructions
+
+          1. cd infra/02-deploy && terraform init && terraform destroy -auto-approve
+          2. cd infra/01-ecr && terraform init && terraform destroy -auto-approve
+          3. Manually delete state bucket: aws s3 rb s3://${{ steps.bucket.outputs.name }} --force
+          TDEOF
+
+          cd /tmp/teardown
+          zip -r /tmp/iac-ci-teardown-${{ github.sha }}.zip .
+
+      - name: Upload teardown archive
+        run: |
+          aws s3 cp /tmp/iac-ci-teardown-${{ github.sha }}.zip \
+            s3://${{ steps.bucket.outputs.name }}/archive/iac-ci-teardown-${{ github.sha }}.zip
+
+      - name: Summary
+        run: |
+          echo "## Deploy Complete" >> $GITHUB_STEP_SUMMARY
+          echo "- API Gateway: ${{ steps.deploy.outputs.api_url }}" >> $GITHUB_STEP_SUMMARY
+          echo "- State Bucket: ${{ steps.bucket.outputs.name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Image Tag: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Teardown archive: s3://${{ steps.bucket.outputs.name }}/archive/iac-ci-teardown-${{ github.sha }}.zip" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,3 +86,45 @@ jobs:
           terraform init -backend=false
           terraform validate
           terraform fmt -check
+
+  script-tests:
+    needs: terraform-validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test generate_backend.sh
+        run: |
+          bash scripts/generate_backend.sh test-bucket ecr us-east-1
+          cat backend.tf
+          grep -q 'bucket = "test-bucket"' backend.tf
+          grep -q 'key    = "ecr/terraform.tfstate"' backend.tf
+          rm backend.tf
+
+      - name: Test generate_tfvars.sh
+        run: |
+          bash scripts/generate_tfvars.sh 123456.dkr.ecr.us-east-1.amazonaws.com/iac-ci abc123 us-east-1
+          cat terraform.tfvars
+          grep -q 'image_tag' terraform.tfvars
+          grep -q 'ecr_repo' terraform.tfvars
+          rm terraform.tfvars
+
+      - name: Test generate_bucket_name.sh
+        run: |
+          BUCKET=$(bash scripts/generate_bucket_name.sh)
+          echo "Generated: $BUCKET"
+          [[ "$BUCKET" == iac-ci-state-* ]]
+
+      - name: Test generate_bucket_name.sh with env override
+        run: |
+          IAC_CI_STATE_BUCKET=my-custom-bucket BUCKET=$(bash scripts/generate_bucket_name.sh)
+          [ "$BUCKET" = "my-custom-bucket" ]
+
+      - name: Validate deploy workflow syntax
+        run: |
+          pip install pyyaml
+          python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"
+
+      - name: Validate test workflow syntax
+        run: |
+          python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"

--- a/scripts/generate_backend.sh
+++ b/scripts/generate_backend.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -ne 3 ]; then
+  echo "Usage: $0 <bucket_name> <stage_key> <region>" >&2
+  exit 1
+fi
+
+BUCKET_NAME="$1"
+STAGE_KEY="$2"
+REGION="$3"
+
+cat > backend.tf <<EOF
+terraform {
+  backend "s3" {
+    bucket = "${BUCKET_NAME}"
+    key    = "${STAGE_KEY}/terraform.tfstate"
+    region = "${REGION}"
+  }
+}
+EOF
+
+echo "Generated backend.tf (bucket=${BUCKET_NAME}, key=${STAGE_KEY}/terraform.tfstate, region=${REGION})"

--- a/scripts/generate_bucket_name.sh
+++ b/scripts/generate_bucket_name.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -n "${IAC_CI_STATE_BUCKET:-}" ]; then
+  echo "$IAC_CI_STATE_BUCKET"
+else
+  echo "iac-ci-state-$(head -c 3 /dev/urandom | xxd -p | cut -c1-5)"
+fi

--- a/scripts/generate_tfvars.sh
+++ b/scripts/generate_tfvars.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -ne 3 ]; then
+  echo "Usage: $0 <ecr_repo_url> <image_tag> <region>" >&2
+  exit 1
+fi
+
+ECR_REPO_URL="$1"
+IMAGE_TAG="$2"
+REGION="$3"
+
+cat > terraform.tfvars <<EOF
+image_tag  = "${IMAGE_TAG}"
+ecr_repo   = "${ECR_REPO_URL}"
+aws_region = "${REGION}"
+EOF
+
+echo "Generated terraform.tfvars (image_tag=${IMAGE_TAG}, region=${REGION})"

--- a/tests/smoke/test_deploy.sh
+++ b/tests/smoke/test_deploy.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PASSED=0
+FAILED=0
+
+pass() { echo "PASS: $1"; ((PASSED++)); }
+fail() { echo "FAIL: $1"; ((FAILED++)); }
+
+# Validate required env vars
+for var in API_GATEWAY_URL AWS_REGION ORDERS_TABLE ORDER_EVENTS_TABLE LOCKS_TABLE INTERNAL_BUCKET DONE_BUCKET; do
+  if [ -z "${!var:-}" ]; then
+    echo "ERROR: $var is not set" >&2
+    exit 1
+  fi
+done
+
+# 1. API Gateway responds (expect 4xx, not 5xx or connection error)
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${API_GATEWAY_URL}/webhook" 2>/dev/null || echo "000")
+if [[ "$HTTP_CODE" =~ ^4[0-9]{2}$ ]]; then
+  pass "API Gateway responds (HTTP $HTTP_CODE)"
+else
+  fail "API Gateway responds (HTTP $HTTP_CODE, expected 4xx)"
+fi
+
+# 2-5. Lambda functions exist
+for FUNC in iac-ci-process-webhook iac-ci-orchestrator iac-ci-watchdog-check iac-ci-worker; do
+  if aws lambda get-function --function-name "$FUNC" --region "$AWS_REGION" >/dev/null 2>&1; then
+    pass "Lambda $FUNC exists"
+  else
+    fail "Lambda $FUNC not found"
+  fi
+done
+
+# 6-8. DynamoDB tables exist
+for TABLE_VAR in ORDERS_TABLE ORDER_EVENTS_TABLE LOCKS_TABLE; do
+  TABLE="${!TABLE_VAR}"
+  if aws dynamodb describe-table --table-name "$TABLE" --region "$AWS_REGION" >/dev/null 2>&1; then
+    pass "DynamoDB table $TABLE exists"
+  else
+    fail "DynamoDB table $TABLE not found"
+  fi
+done
+
+# 9-10. S3 buckets exist
+for BUCKET_VAR in INTERNAL_BUCKET DONE_BUCKET; do
+  BUCKET="${!BUCKET_VAR}"
+  if aws s3api head-bucket --bucket "$BUCKET" --region "$AWS_REGION" 2>/dev/null; then
+    pass "S3 bucket $BUCKET exists"
+  else
+    fail "S3 bucket $BUCKET not found"
+  fi
+done
+
+# 11. Step Function exists
+if aws stepfunctions list-state-machines --region "$AWS_REGION" 2>/dev/null | grep -q "iac-ci-watchdog"; then
+  pass "Step Function iac-ci-watchdog exists"
+else
+  fail "Step Function iac-ci-watchdog not found"
+fi
+
+# 12. S3 notification configured on internal bucket
+NOTIF=$(aws s3api get-bucket-notification-configuration --bucket "$INTERNAL_BUCKET" --region "$AWS_REGION" 2>/dev/null || echo "{}")
+if echo "$NOTIF" | grep -q "LambdaFunctionConfigurations"; then
+  pass "S3 notification configured on $INTERNAL_BUCKET"
+else
+  fail "S3 notification not configured on $INTERNAL_BUCKET"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+
+if [ "$FAILED" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
Scripts:
- generate_backend.sh: creates backend.tf for S3 remote state
- generate_tfvars.sh: creates terraform.tfvars for 02-deploy
- generate_bucket_name.sh: resolves or auto-generates state bucket name

Deploy workflow (deploy.yml):
- 6-step workflow_dispatch: bootstrap → ECR → Docker build/push → deploy infra → smoke tests → archive for teardown
- Extracts map outputs via jq for smoke test env vars

Smoke tests (test_deploy.sh):
- 12 checks: API Gateway, 4 Lambdas, 3 DynamoDB tables, 2 S3 buckets, Step Function, S3 notification config

GHA test workflow:
- Adds script-tests job validating all 3 scripts + YAML syntax

https://claude.ai/code/session_01W2YnwLhkhqMdDkDuisMJLJ