### PR TITLE
Add shared events directory model to worker execution

### DIFF
--- a/infra/02-deploy/iam.tf
+++ b/infra/02-deploy/iam.tf
@@ -195,6 +195,11 @@ resource "aws_iam_role_policy" "worker" {
         Action   = ["s3:GetObject"]
         Resource = "${aws_s3_bucket.internal.arn}/tmp/exec/*"
       },
+      {
+        Effect   = "Allow"
+        Action   = ["dynamodb:PutItem"]
+        Resource = aws_dynamodb_table.order_events.arn
+      },
     ]
   })
 }
@@ -247,6 +252,11 @@ resource "aws_iam_role_policy" "codebuild" {
         Effect   = "Allow"
         Action   = ["s3:GetObject"]
         Resource = "${aws_s3_bucket.internal.arn}/tmp/exec/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["dynamodb:PutItem"]
+        Resource = aws_dynamodb_table.order_events.arn
       },
       {
         Effect = "Allow"

--- a/tests/integration/test_worker_events.py
+++ b/tests/integration/test_worker_events.py
@@ -1,0 +1,168 @@
+"""Integration test: worker subprocess events → DynamoDB order_events."""
+
+import json
+import os
+import tempfile
+import zipfile
+from unittest.mock import patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+
+# ── Fixtures ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def aws_env(monkeypatch):
+    """Set up environment variables for mocked AWS."""
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("IAC_CI_ORDERS_TABLE", "test-orders")
+    monkeypatch.setenv("IAC_CI_ORDER_EVENTS_TABLE", "test-order-events")
+    monkeypatch.setenv("IAC_CI_LOCKS_TABLE", "test-locks")
+    monkeypatch.setenv("IAC_CI_INTERNAL_BUCKET", "test-internal")
+    monkeypatch.setenv("IAC_CI_DONE_BUCKET", "test-done")
+
+
+@pytest.fixture
+def mock_aws_resources(aws_env):
+    """Create mocked DynamoDB tables and S3 buckets."""
+    with mock_aws():
+        region = "us-east-1"
+
+        # DynamoDB
+        ddb = boto3.resource("dynamodb", region_name=region)
+        ddb.create_table(
+            TableName="test-order-events",
+            KeySchema=[
+                {"AttributeName": "trace_id", "KeyType": "HASH"},
+                {"AttributeName": "sk", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "trace_id", "AttributeType": "S"},
+                {"AttributeName": "sk", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        # S3
+        s3 = boto3.client("s3", region_name=region)
+        s3.create_bucket(Bucket="test-internal")
+
+        yield {"ddb": ddb, "s3": s3}
+
+
+# ── Tests ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+class TestWorkerEvents:
+
+    @patch("src.worker.run.send_callback")
+    @patch("src.common.sops.decrypt_env")
+    def test_subprocess_events_reach_dynamodb(
+        self, mock_sops_decrypt, mock_callback, mock_aws_resources,
+    ):
+        """A command writes a JSON event file to $IAC_CI_EVENTS_DIR.
+        After execution, the worker reads it and writes to DynamoDB."""
+
+        trace_id = "test-trace-events"
+        order_name = "plan-order"
+
+        # Mock SOPS to return engine env vars
+        mock_sops_decrypt.return_value = {
+            "TRACE_ID": trace_id,
+            "ORDER_ID": order_name,
+            "ORDER_NUM": "0001",
+            "FLOW_ID": "user:test-flow",
+            "RUN_ID": "run-evt-1",
+            "CALLBACK_URL": "https://callback.test",
+            "CMDS": json.dumps([
+                # The subprocess writes a JSON event file to $IAC_CI_EVENTS_DIR
+                'echo \'{"event_type":"tf_plan","status":"succeeded","message":"Plan: 2 to add"}\' > $IAC_CI_EVENTS_DIR/tf_plan.json',
+            ]),
+        }
+
+        # Create a minimal exec.zip with a secrets.enc.json
+        s3 = mock_aws_resources["s3"]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            import io
+            buf = io.BytesIO()
+            with zipfile.ZipFile(buf, "w") as zf:
+                zf.writestr("secrets.enc.json", "{}")
+            buf.seek(0)
+            s3.put_object(
+                Bucket="test-internal",
+                Key="tmp/exec/run-evt-1/0001/exec.zip",
+                Body=buf.read(),
+            )
+
+        from src.worker.run import run
+        status = run("s3://test-internal/tmp/exec/run-evt-1/0001/exec.zip")
+
+        assert status == "succeeded"
+
+        # Verify the event was written to DynamoDB
+        ddb = mock_aws_resources["ddb"]
+        events_table = ddb.Table("test-order-events")
+        result = events_table.scan()
+        items = result["Items"]
+
+        assert len(items) == 1
+        event = items[0]
+        assert event["trace_id"] == trace_id
+        assert event["order_name"] == order_name
+        assert event["event_type"] == "tf_plan"
+        assert event["status"] == "succeeded"
+        assert event["message"] == "Plan: 2 to add"
+        assert event["flow_id"] == "user:test-flow"
+        assert event["run_id"] == "run-evt-1"
+
+        # Verify callback was still sent
+        mock_callback.assert_called_once()
+        assert mock_callback.call_args[0][1] == "succeeded"
+
+    @patch("src.worker.run.send_callback")
+    @patch("src.common.sops.decrypt_env")
+    def test_no_events_written_when_subprocess_writes_nothing(
+        self, mock_sops_decrypt, mock_callback, mock_aws_resources,
+    ):
+        """When no event files are written, DynamoDB stays empty."""
+
+        mock_sops_decrypt.return_value = {
+            "TRACE_ID": "trace-no-events",
+            "ORDER_ID": "simple-order",
+            "ORDER_NUM": "0001",
+            "FLOW_ID": "user:test",
+            "RUN_ID": "run-no-evt",
+            "CALLBACK_URL": "https://callback.test",
+            "CMDS": json.dumps(["echo hello"]),
+        }
+
+        s3 = mock_aws_resources["s3"]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            import io
+            buf = io.BytesIO()
+            with zipfile.ZipFile(buf, "w") as zf:
+                zf.writestr("secrets.enc.json", "{}")
+            buf.seek(0)
+            s3.put_object(
+                Bucket="test-internal",
+                Key="tmp/exec/run-no-evt/0001/exec.zip",
+                Body=buf.read(),
+            )
+
+        from src.worker.run import run
+        status = run("s3://test-internal/tmp/exec/run-no-evt/0001/exec.zip")
+
+        assert status == "succeeded"
+
+        ddb = mock_aws_resources["ddb"]
+        events_table = ddb.Table("test-order-events")
+        result = events_table.scan()
+        assert len(result["Items"]) == 0

--- a/tests/unit/test_worker_run.py
+++ b/tests/unit/test_worker_run.py
@@ -4,11 +4,17 @@ import json
 import os
 import tempfile
 import zipfile
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
 import pytest
 
-from src.worker.run import run, _execute_commands, _download_and_extract
+from src.worker.run import (
+    run,
+    _execute_commands,
+    _download_and_extract,
+    _setup_events_dir,
+    _collect_and_write_events,
+)
 
 
 class TestExecuteCommands:
@@ -64,18 +70,164 @@ class TestExecuteCommands:
             assert "error_msg" in log
 
 
+class TestSetupEventsDir:
+    def test_creates_directory(self):
+        with tempfile.TemporaryDirectory() as base:
+            with patch.dict(os.environ, {}, clear=False):
+                trace_id = "test-trace-123"
+                # Override the base path to use temp dir
+                with patch("src.worker.run._setup_events_dir") as _:
+                    events_dir = os.path.join(base, trace_id, "events")
+                    os.makedirs(events_dir, exist_ok=True)
+                    assert os.path.isdir(events_dir)
+
+    def test_sets_env_var(self):
+        with patch.dict(os.environ, {}, clear=False):
+            trace_id = "test-trace-456"
+            events_dir = _setup_events_dir(trace_id)
+            assert os.environ["IAC_CI_EVENTS_DIR"] == events_dir
+            assert events_dir == f"/var/tmp/share/{trace_id}/events"
+
+    def test_idempotent(self):
+        trace_id = "test-trace-789"
+        dir1 = _setup_events_dir(trace_id)
+        dir2 = _setup_events_dir(trace_id)
+        assert dir1 == dir2
+        assert os.path.isdir(dir1)
+
+
+class TestCollectAndWriteEvents:
+    @patch("src.worker.run.dynamodb.put_event")
+    def test_writes_events_to_dynamodb(self, mock_put_event):
+        with tempfile.TemporaryDirectory() as events_dir:
+            # Write two event files
+            with open(os.path.join(events_dir, "tf_plan.json"), "w") as f:
+                json.dump({
+                    "event_type": "tf_plan",
+                    "status": "succeeded",
+                    "message": "Plan: 3 to add",
+                }, f)
+            with open(os.path.join(events_dir, "tf_apply.json"), "w") as f:
+                json.dump({
+                    "event_type": "tf_apply",
+                    "status": "succeeded",
+                }, f)
+
+            count = _collect_and_write_events(
+                events_dir, "trace-1", "my-order", "flow-1", "run-1",
+            )
+
+            assert count == 2
+            assert mock_put_event.call_count == 2
+
+            # Verify first call (tf_apply.json comes first alphabetically)
+            calls = mock_put_event.call_args_list
+            # Files are sorted, so tf_apply before tf_plan
+            call_args_0 = calls[0]
+            assert call_args_0[1]["trace_id"] == "trace-1"
+            assert call_args_0[1]["order_name"] == "my-order"
+            assert call_args_0[1]["event_type"] == "tf_apply"
+            assert call_args_0[1]["status"] == "succeeded"
+            assert call_args_0[1]["extra_fields"]["flow_id"] == "flow-1"
+            assert call_args_0[1]["extra_fields"]["run_id"] == "run-1"
+
+            call_args_1 = calls[1]
+            assert call_args_1[1]["event_type"] == "tf_plan"
+            assert call_args_1[1]["extra_fields"]["message"] == "Plan: 3 to add"
+
+    @patch("src.worker.run.dynamodb.put_event")
+    def test_empty_dir_no_calls(self, mock_put_event):
+        with tempfile.TemporaryDirectory() as events_dir:
+            count = _collect_and_write_events(
+                events_dir, "trace-1", "my-order",
+            )
+            assert count == 0
+            mock_put_event.assert_not_called()
+
+    @patch("src.worker.run.dynamodb.put_event")
+    def test_nonexistent_dir_no_calls(self, mock_put_event):
+        count = _collect_and_write_events(
+            "/nonexistent/path", "trace-1", "my-order",
+        )
+        assert count == 0
+        mock_put_event.assert_not_called()
+
+    @patch("src.worker.run.dynamodb.put_event")
+    def test_malformed_json_skipped(self, mock_put_event):
+        with tempfile.TemporaryDirectory() as events_dir:
+            # Write invalid JSON
+            with open(os.path.join(events_dir, "bad.json"), "w") as f:
+                f.write("not valid json{{{")
+            # Write valid JSON
+            with open(os.path.join(events_dir, "good.json"), "w") as f:
+                json.dump({"event_type": "ok", "status": "info"}, f)
+
+            count = _collect_and_write_events(
+                events_dir, "trace-1", "my-order",
+            )
+            assert count == 1
+            mock_put_event.assert_called_once()
+
+    @patch("src.worker.run.dynamodb.put_event")
+    def test_non_dict_json_skipped(self, mock_put_event):
+        with tempfile.TemporaryDirectory() as events_dir:
+            with open(os.path.join(events_dir, "array.json"), "w") as f:
+                json.dump([1, 2, 3], f)
+
+            count = _collect_and_write_events(
+                events_dir, "trace-1", "my-order",
+            )
+            assert count == 0
+            mock_put_event.assert_not_called()
+
+    @patch("src.worker.run.dynamodb.put_event")
+    def test_missing_fields_uses_fallbacks(self, mock_put_event):
+        with tempfile.TemporaryDirectory() as events_dir:
+            # JSON with no event_type or status — uses filename stem and "info"
+            with open(os.path.join(events_dir, "custom_check.json"), "w") as f:
+                json.dump({"message": "all good"}, f)
+
+            count = _collect_and_write_events(
+                events_dir, "trace-1", "my-order",
+            )
+            assert count == 1
+            call_kwargs = mock_put_event.call_args[1]
+            assert call_kwargs["event_type"] == "custom_check"
+            assert call_kwargs["status"] == "info"
+            assert call_kwargs["extra_fields"]["message"] == "all good"
+
+    @patch("src.worker.run.dynamodb.put_event")
+    def test_dynamodb_error_does_not_crash(self, mock_put_event):
+        mock_put_event.side_effect = Exception("DynamoDB unavailable")
+        with tempfile.TemporaryDirectory() as events_dir:
+            with open(os.path.join(events_dir, "event.json"), "w") as f:
+                json.dump({"event_type": "test", "status": "ok"}, f)
+
+            count = _collect_and_write_events(
+                events_dir, "trace-1", "my-order",
+            )
+            assert count == 0  # Failed to write
+
+
 class TestRun:
+    @patch("src.worker.run._collect_and_write_events")
     @patch("src.worker.run.send_callback")
     @patch("src.worker.run._decrypt_and_load_env")
     @patch("src.worker.run._download_and_extract")
-    def test_successful_run(self, mock_download, mock_decrypt, mock_callback):
+    def test_successful_run(self, mock_download, mock_decrypt, mock_callback, mock_collect):
         with tempfile.TemporaryDirectory() as tmpdir:
             # Create cmds.json
             with open(os.path.join(tmpdir, "cmds.json"), "w") as f:
                 json.dump(["echo hello"], f)
 
             mock_download.return_value = tmpdir
-            mock_decrypt.return_value = {"CALLBACK_URL": "https://cb.url"}
+            mock_decrypt.return_value = {
+                "CALLBACK_URL": "https://cb.url",
+                "TRACE_ID": "tr-1",
+                "ORDER_ID": "order-1",
+                "FLOW_ID": "flow-1",
+                "RUN_ID": "run-1",
+            }
 
             status = run("s3://bucket/exec.zip")
 
@@ -85,22 +237,37 @@ class TestRun:
             assert call_args[0] == "https://cb.url"
             assert call_args[1] == "succeeded"
 
+            # Verify events collection was called
+            mock_collect.assert_called_once()
+            collect_args = mock_collect.call_args[0]
+            assert collect_args[1] == "tr-1"   # trace_id
+            assert collect_args[2] == "order-1" # order_name
+            assert collect_args[3] == "flow-1"  # flow_id
+            assert collect_args[4] == "run-1"   # run_id
+
+    @patch("src.worker.run._collect_and_write_events")
     @patch("src.worker.run.send_callback")
     @patch("src.worker.run._decrypt_and_load_env")
     @patch("src.worker.run._download_and_extract")
-    def test_failed_run(self, mock_download, mock_decrypt, mock_callback):
+    def test_failed_run(self, mock_download, mock_decrypt, mock_callback, mock_collect):
         with tempfile.TemporaryDirectory() as tmpdir:
             with open(os.path.join(tmpdir, "cmds.json"), "w") as f:
                 json.dump(["exit 1"], f)
 
             mock_download.return_value = tmpdir
-            mock_decrypt.return_value = {"CALLBACK_URL": "https://cb.url"}
+            mock_decrypt.return_value = {
+                "CALLBACK_URL": "https://cb.url",
+                "TRACE_ID": "tr-1",
+                "ORDER_ID": "order-1",
+            }
 
             status = run("s3://bucket/exec.zip")
 
             assert status == "failed"
             mock_callback.assert_called_once()
             assert mock_callback.call_args[0][1] == "failed"
+            # Events still collected even on failure
+            mock_collect.assert_called_once()
 
     @patch("src.worker.run.send_callback")
     @patch("src.worker.run._decrypt_and_load_env")
@@ -114,17 +281,38 @@ class TestRun:
 
             assert status == "failed"
 
+    @patch("src.worker.run._collect_and_write_events")
     @patch("src.worker.run.send_callback")
     @patch("src.worker.run._decrypt_and_load_env")
     @patch("src.worker.run._download_and_extract")
-    def test_cmds_from_env(self, mock_download, mock_decrypt, mock_callback):
+    def test_cmds_from_env(self, mock_download, mock_decrypt, mock_callback, mock_collect):
         with tempfile.TemporaryDirectory() as tmpdir:
             mock_download.return_value = tmpdir
             mock_decrypt.return_value = {
                 "CALLBACK_URL": "https://cb.url",
                 "CMDS": json.dumps(["echo from_env"]),
+                "TRACE_ID": "tr-1",
+                "ORDER_ID": "order-1",
             }
 
             status = run("s3://bucket/exec.zip")
 
             assert status == "succeeded"
+
+    @patch("src.worker.run._collect_and_write_events")
+    @patch("src.worker.run.send_callback")
+    @patch("src.worker.run._decrypt_and_load_env")
+    @patch("src.worker.run._download_and_extract")
+    def test_no_trace_id_skips_events(self, mock_download, mock_decrypt, mock_callback, mock_collect):
+        """Without TRACE_ID, events dir is not set up and collection is skipped."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "cmds.json"), "w") as f:
+                json.dump(["echo hello"], f)
+
+            mock_download.return_value = tmpdir
+            mock_decrypt.return_value = {"CALLBACK_URL": "https://cb.url"}
+
+            status = run("s3://bucket/exec.zip")
+
+            assert status == "succeeded"
+            mock_collect.assert_not_called()


### PR DESCRIPTION
Workers now create /var/tmp/share/{trace_id}/events/ before spawning subprocesses. Subprocesses write JSON event files to this directory (discoverable via $IAC_CI_EVENTS_DIR env var). After command execution, the main process reads all event files and transfers them to the DynamoDB order_events table, giving structured event visibility without subprocesses needing AWS credentials or engine knowledge.

- Add _setup_events_dir() and _collect_and_write_events() to worker
- Grant dynamodb:PutItem on order_events to worker Lambda and CodeBuild roles
- Add unit tests for events dir setup, collection, fallbacks, and error handling
- Add integration test for end-to-end subprocess event → DynamoDB flow

https://claude.ai/code/session_01E5Y8H8dUAt9cJm7AjnLWsW