### PR TITLE
Smart repackage grouping: clone once per unique (repo, commit_hash)

### DIFF
--- a/src/common/models.py
+++ b/src/common/models.py
@@ -27,6 +27,7 @@ class Order:
     order_name: Optional[str] = None
     git_repo: Optional[str] = None
     git_folder: Optional[str] = None
+    commit_hash: Optional[str] = None
     s3_location: Optional[str] = None
     env_vars: Optional[Dict[str, str]] = None
     ssm_paths: Optional[List[str]] = None
@@ -59,6 +60,7 @@ class Job:
     pr_number: Optional[int] = None
     issue_number: Optional[int] = None
     git_ssh_key_location: Optional[str] = None
+    commit_hash: Optional[str] = None
     flow_label: str = "exec"
     pr_comment_search_tag: Optional[str] = None
     presign_expiry: int = 7200

--- a/src/init_job/insert.py
+++ b/src/init_job/insert.py
@@ -30,6 +30,7 @@ def insert_orders(
         # Build git b64 if using git source
         git_b64 = None
         if not order.s3_location:
+            commit = order.commit_hash or job.commit_hash
             git_data = {
                 "repo": order.git_repo or job.git_repo,
                 "token_location": job.git_token_location,
@@ -37,6 +38,8 @@ def insert_orders(
             }
             if job.git_ssh_key_location:
                 git_data["ssh_key_location"] = job.git_ssh_key_location
+            if commit:
+                git_data["commit_hash"] = commit
             git_b64 = base64.b64encode(json.dumps(git_data).encode()).decode()
 
         s3_location = f"s3://{internal_bucket}/tmp/exec/{run_id}/{order_num}/exec.zip"

--- a/src/init_job/repackage.py
+++ b/src/init_job/repackage.py
@@ -41,24 +41,79 @@ def _fetch_secret_values(paths: List[str], region: Optional[str] = None) -> Dict
     return result
 
 
-def _fetch_code_git(
+def _clone_repo(
     repo: str,
     token_location: str,
-    folder: Optional[str] = None,
+    commit_hash: Optional[str] = None,
     ssh_key_location: Optional[str] = None,
 ) -> str:
-    """Clone a git repo and return path to code directory."""
+    """Clone a git repo and optionally checkout a specific commit.
+
+    Returns the path to the repository root directory.
+    Uses --depth 1 for HEAD, --depth 2 when a specific commit_hash is requested.
+    """
     work_dir = tempfile.mkdtemp(prefix="iac-ci-git-")
     clone_url = f"https://github.com/{repo}.git"
+
+    depth = "2" if commit_hash else "1"
     subprocess.run(
-        ["git", "clone", "--depth", "1", clone_url, work_dir],
+        ["git", "clone", "--depth", depth, clone_url, work_dir],
         check=True,
         capture_output=True,
         text=True,
     )
-    if folder:
-        return os.path.join(work_dir, folder)
+
+    if commit_hash:
+        subprocess.run(
+            ["git", "checkout", commit_hash],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=work_dir,
+        )
+
     return work_dir
+
+
+def _extract_folder(clone_dir: str, folder: Optional[str] = None) -> str:
+    """Copy a folder (or the entire repo) from a shared clone into an isolated temp dir.
+
+    Each order needs its own copy because OrderBundler writes files in-place.
+    Excludes .git directory to save space.
+    """
+    source = os.path.join(clone_dir, folder) if folder else clone_dir
+    if not os.path.isdir(source):
+        raise FileNotFoundError(
+            f"Folder '{folder}' not found in cloned repo at {clone_dir}"
+        )
+    isolated_dir = tempfile.mkdtemp(prefix="iac-ci-order-")
+    shutil.copytree(source, isolated_dir, dirs_exist_ok=True,
+                    ignore=shutil.ignore_patterns(".git"))
+    return isolated_dir
+
+
+def _group_git_orders(
+    job: Job,
+) -> Tuple[Dict[Tuple[str, Optional[str]], List[Tuple[int, Order]]], List[int]]:
+    """Group git-sourced orders by (repo, commit_hash).
+
+    Returns:
+        git_groups: dict mapping (repo, commit_hash) -> list of (order_index, order)
+        s3_indices: list of order indices that use S3 source
+    """
+    git_groups: Dict[Tuple[str, Optional[str]], List[Tuple[int, Order]]] = {}
+    s3_indices: List[int] = []
+
+    for i, order in enumerate(job.orders):
+        if order.s3_location:
+            s3_indices.append(i)
+        else:
+            repo = order.git_repo or job.git_repo
+            commit = order.commit_hash or job.commit_hash
+            key = (repo, commit)
+            git_groups.setdefault(key, []).append((i, order))
+
+    return git_groups, s3_indices
 
 
 def _fetch_code_s3(s3_location: str) -> str:
@@ -90,6 +145,59 @@ def _zip_directory(code_dir: str, output_path: str) -> str:
     return output_path
 
 
+def _process_order(
+    job: Job,
+    order: Order,
+    order_index: int,
+    code_dir: str,
+    run_id: str,
+    trace_id: str,
+    flow_id: str,
+    internal_bucket: str,
+) -> Dict:
+    """Process a single order: fetch credentials, bundle, zip."""
+    order_num = str(order_index + 1).zfill(4)
+    order_name = order.order_name or f"order-{order_num}"
+
+    # Fetch credentials
+    ssm_values = _fetch_ssm_values(order.ssm_paths or [])
+    secret_values = _fetch_secret_values(order.secret_manager_paths or [])
+
+    # Generate presigned callback URL
+    callback_url = s3_ops.generate_callback_presigned_url(
+        bucket=internal_bucket,
+        run_id=run_id,
+        order_num=order_num,
+        expiry=job.presign_expiry,
+    )
+
+    # Build and encrypt with OrderBundler
+    bundler = OrderBundler(
+        run_id=run_id,
+        order_id=order_name,
+        order_num=order_num,
+        trace_id=trace_id,
+        flow_id=flow_id,
+        env_vars=order.env_vars or {},
+        ssm_values=ssm_values,
+        secret_values=secret_values,
+        callback_url=callback_url,
+    )
+    bundler.repackage(code_dir, sops_key=order.sops_key)
+
+    # Re-zip
+    zip_path = os.path.join(tempfile.gettempdir(), f"{run_id}_{order_num}_exec.zip")
+    _zip_directory(code_dir, zip_path)
+
+    return {
+        "order_num": order_num,
+        "order_name": order_name,
+        "zip_path": zip_path,
+        "callback_url": callback_url,
+        "code_dir": code_dir,
+    }
+
+
 def repackage_orders(
     job: Job,
     run_id: str,
@@ -99,63 +207,57 @@ def repackage_orders(
 ) -> List[Dict]:
     """Repackage all orders with credentials and SOPS encryption.
 
+    Groups git-sourced orders by (repo, commit_hash) to avoid redundant clones.
+
     Returns list of dicts with keys:
         order_num, order_name, zip_path, callback_url, code_dir
     """
-    results = []
+    results: List[Optional[Dict]] = [None] * len(job.orders)
+    shared_clone_dirs: List[str] = []
 
-    for i, order in enumerate(job.orders):
-        order_num = str(i + 1).zfill(4)
-        order_name = order.order_name or f"order-{order_num}"
+    try:
+        # Phase 1: Group git orders and clone once per unique (repo, commit_hash)
+        git_groups, s3_indices = _group_git_orders(job)
 
-        # 1. Fetch code
-        if order.s3_location:
-            code_dir = _fetch_code_s3(order.s3_location)
-        else:
-            repo = order.git_repo or job.git_repo
-            code_dir = _fetch_code_git(
+        for (repo, commit_hash), order_entries in git_groups.items():
+            clone_dir = _clone_repo(
                 repo=repo,
                 token_location=job.git_token_location,
-                folder=order.git_folder,
+                commit_hash=commit_hash,
                 ssh_key_location=job.git_ssh_key_location,
             )
+            shared_clone_dirs.append(clone_dir)
 
-        # 2. Fetch credentials
-        ssm_values = _fetch_ssm_values(order.ssm_paths or [])
-        secret_values = _fetch_secret_values(order.secret_manager_paths or [])
+            for i, order in order_entries:
+                code_dir = _extract_folder(clone_dir, order.git_folder)
+                results[i] = _process_order(
+                    job=job,
+                    order=order,
+                    order_index=i,
+                    code_dir=code_dir,
+                    run_id=run_id,
+                    trace_id=trace_id,
+                    flow_id=flow_id,
+                    internal_bucket=internal_bucket,
+                )
 
-        # 3. Generate presigned callback URL
-        callback_url = s3_ops.generate_callback_presigned_url(
-            bucket=internal_bucket,
-            run_id=run_id,
-            order_num=order_num,
-            expiry=job.presign_expiry,
-        )
-
-        # 4. Build and encrypt with OrderBundler
-        bundler = OrderBundler(
-            run_id=run_id,
-            order_id=order_name,
-            order_num=order_num,
-            trace_id=trace_id,
-            flow_id=flow_id,
-            env_vars=order.env_vars or {},
-            ssm_values=ssm_values,
-            secret_values=secret_values,
-            callback_url=callback_url,
-        )
-        bundler.repackage(code_dir, sops_key=order.sops_key)
-
-        # 5. Re-zip
-        zip_path = os.path.join(tempfile.gettempdir(), f"{run_id}_{order_num}_exec.zip")
-        _zip_directory(code_dir, zip_path)
-
-        results.append({
-            "order_num": order_num,
-            "order_name": order_name,
-            "zip_path": zip_path,
-            "callback_url": callback_url,
-            "code_dir": code_dir,
-        })
+        # Phase 2: Process S3-sourced orders (unchanged)
+        for i in s3_indices:
+            order = job.orders[i]
+            code_dir = _fetch_code_s3(order.s3_location)
+            results[i] = _process_order(
+                job=job,
+                order=order,
+                order_index=i,
+                code_dir=code_dir,
+                run_id=run_id,
+                trace_id=trace_id,
+                flow_id=flow_id,
+                internal_bucket=internal_bucket,
+            )
+    finally:
+        # Clean up shared clone directories
+        for clone_dir in shared_clone_dirs:
+            shutil.rmtree(clone_dir, ignore_errors=True)
 
     return results

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -81,6 +81,20 @@ class TestOrder:
         assert order.order_name == "test-order"
         assert order.use_lambda is True
 
+    def test_commit_hash_field(self):
+        order = Order(cmds=["echo"], timeout=300, commit_hash="abc123")
+        assert order.commit_hash == "abc123"
+
+    def test_commit_hash_in_to_dict(self):
+        order = Order(cmds=["echo"], timeout=300, commit_hash="abc123")
+        d = order.to_dict()
+        assert d["commit_hash"] == "abc123"
+
+    def test_commit_hash_excluded_when_none(self):
+        order = Order(cmds=["echo"], timeout=300)
+        d = order.to_dict()
+        assert "commit_hash" not in d
+
     def test_to_dict_from_dict_roundtrip(self):
         order = Order(
             cmds=["cmd1"],
@@ -153,6 +167,37 @@ class TestJob:
         assert restored.username == job.username
         assert len(restored.orders) == len(job.orders)
         assert restored.orders[0].order_name == job.orders[0].order_name
+
+    def test_commit_hash_field(self):
+        job = Job(
+            git_repo="org/repo",
+            git_token_location="token",
+            username="user",
+            orders=[],
+            commit_hash="abc123",
+        )
+        assert job.commit_hash == "abc123"
+
+    def test_commit_hash_b64_roundtrip(self):
+        job = Job(
+            git_repo="org/repo",
+            git_token_location="token",
+            username="user",
+            orders=[Order(cmds=["echo"], timeout=300)],
+            commit_hash="abc123",
+        )
+        restored = Job.from_b64(job.to_b64())
+        assert restored.commit_hash == "abc123"
+
+    def test_commit_hash_excluded_when_none(self):
+        job = Job(
+            git_repo="org/repo",
+            git_token_location="token",
+            username="user",
+            orders=[],
+        )
+        d = job.to_dict()
+        assert "commit_hash" not in d
 
     def test_default_flow_label(self):
         job = Job(

--- a/tests/unit/test_repackage.py
+++ b/tests/unit/test_repackage.py
@@ -1,6 +1,7 @@
 """Unit tests for src/init_job/repackage.py."""
 
 import os
+import shutil
 import tempfile
 from unittest.mock import patch, MagicMock
 
@@ -9,6 +10,8 @@ import pytest
 from src.common.models import Job, Order
 from src.init_job.repackage import (
     repackage_orders,
+    _extract_folder,
+    _group_git_orders,
     _fetch_ssm_values,
     _fetch_secret_values,
     _zip_directory,
@@ -50,19 +53,119 @@ class TestZipDirectory:
             assert os.path.getsize(zip_path) > 0
 
 
+class TestExtractFolder:
+    def test_copies_entire_clone(self):
+        with tempfile.TemporaryDirectory() as clone_dir:
+            with open(os.path.join(clone_dir, "main.tf"), "w") as f:
+                f.write("resource {}")
+
+            result = _extract_folder(clone_dir)
+            try:
+                assert os.path.isdir(result)
+                assert os.path.exists(os.path.join(result, "main.tf"))
+            finally:
+                shutil.rmtree(result, ignore_errors=True)
+
+    def test_copies_subfolder(self):
+        with tempfile.TemporaryDirectory() as clone_dir:
+            os.makedirs(os.path.join(clone_dir, "vpc"))
+            with open(os.path.join(clone_dir, "vpc", "main.tf"), "w") as f:
+                f.write("vpc resource")
+            with open(os.path.join(clone_dir, "root.txt"), "w") as f:
+                f.write("root")
+
+            result = _extract_folder(clone_dir, "vpc")
+            try:
+                assert os.path.exists(os.path.join(result, "main.tf"))
+                # root.txt should NOT be present (only vpc/ contents copied)
+                assert not os.path.exists(os.path.join(result, "root.txt"))
+            finally:
+                shutil.rmtree(result, ignore_errors=True)
+
+    def test_excludes_git_dir(self):
+        with tempfile.TemporaryDirectory() as clone_dir:
+            os.makedirs(os.path.join(clone_dir, ".git"))
+            with open(os.path.join(clone_dir, ".git", "HEAD"), "w") as f:
+                f.write("ref: refs/heads/main")
+            with open(os.path.join(clone_dir, "main.tf"), "w") as f:
+                f.write("resource {}")
+
+            result = _extract_folder(clone_dir)
+            try:
+                assert os.path.exists(os.path.join(result, "main.tf"))
+                assert not os.path.exists(os.path.join(result, ".git"))
+            finally:
+                shutil.rmtree(result, ignore_errors=True)
+
+    def test_missing_folder_raises(self):
+        with tempfile.TemporaryDirectory() as clone_dir:
+            with pytest.raises(FileNotFoundError, match="nonexistent"):
+                _extract_folder(clone_dir, "nonexistent")
+
+
+class TestGroupGitOrders:
+    def test_groups_same_repo(self):
+        job = _make_job(orders=[
+            _make_order(order_name="a", git_folder="vpc"),
+            _make_order(order_name="b", git_folder="rds"),
+        ])
+        git_groups, s3_indices = _group_git_orders(job)
+        assert len(git_groups) == 1
+        assert len(s3_indices) == 0
+        key = ("org/repo", None)
+        assert len(git_groups[key]) == 2
+
+    def test_different_repos_separate_groups(self):
+        job = _make_job(orders=[
+            _make_order(order_name="a", git_repo="org/repo-a"),
+            _make_order(order_name="b", git_repo="org/repo-b"),
+        ])
+        git_groups, s3_indices = _group_git_orders(job)
+        assert len(git_groups) == 2
+
+    def test_same_repo_different_commits_separate(self):
+        job = _make_job(orders=[
+            _make_order(order_name="a", commit_hash="abc123"),
+            _make_order(order_name="b", commit_hash="def456"),
+        ])
+        git_groups, s3_indices = _group_git_orders(job)
+        assert len(git_groups) == 2
+
+    def test_job_level_commit_hash_groups_orders(self):
+        job = _make_job(
+            commit_hash="abc123",
+            orders=[
+                _make_order(order_name="a", git_folder="vpc"),
+                _make_order(order_name="b", git_folder="rds"),
+            ],
+        )
+        git_groups, s3_indices = _group_git_orders(job)
+        assert len(git_groups) == 1
+        key = ("org/repo", "abc123")
+        assert len(git_groups[key]) == 2
+
+    def test_s3_orders_separated(self):
+        job = _make_job(orders=[
+            _make_order(order_name="git-order", git_folder="vpc"),
+            _make_order(order_name="s3-order", s3_location="s3://bucket/code.zip"),
+        ])
+        git_groups, s3_indices = _group_git_orders(job)
+        assert len(git_groups) == 1
+        assert s3_indices == [1]
+
+
 class TestRepackageOrders:
-    @patch("src.init_job.repackage._fetch_code_git")
+    @patch("src.init_job.repackage._clone_repo")
     @patch("src.init_job.repackage._fetch_ssm_values")
     @patch("src.init_job.repackage._fetch_secret_values")
     @patch("src.init_job.repackage.s3_ops.generate_callback_presigned_url")
     @patch("src.init_job.repackage.OrderBundler")
     def test_repackage_produces_correct_structure(
         self, MockBundler, mock_presign, mock_secrets,
-        mock_ssm, mock_git,
+        mock_ssm, mock_clone,
     ):
-        with tempfile.TemporaryDirectory() as code_dir:
-            # Setup mocks
-            mock_git.return_value = code_dir
+        with tempfile.TemporaryDirectory() as clone_dir:
+            mock_clone.return_value = clone_dir
             mock_ssm.return_value = {"DB_PASS": "secret"}
             mock_secrets.return_value = {}
             mock_presign.return_value = "https://presigned.url"
@@ -70,8 +173,7 @@ class TestRepackageOrders:
             bundler_instance = MagicMock()
             MockBundler.return_value = bundler_instance
 
-            # Create a file in code_dir so zip isn't empty
-            with open(os.path.join(code_dir, "main.tf"), "w") as f:
+            with open(os.path.join(clone_dir, "main.tf"), "w") as f:
                 f.write("resource {}")
 
             job = _make_job(orders=[
@@ -92,6 +194,9 @@ class TestRepackageOrders:
             assert r["order_name"] == "deploy-vpc"
             assert r["callback_url"] == "https://presigned.url"
             assert os.path.exists(r["zip_path"])
+
+            # Single clone call
+            mock_clone.assert_called_once()
 
             # Verify bundler was created with correct args
             MockBundler.assert_called_once()
@@ -134,28 +239,33 @@ class TestRepackageOrders:
             assert len(results) == 1
             mock_s3.assert_called_once_with("s3://bucket/code.zip")
 
-    @patch("src.init_job.repackage._fetch_code_git")
+    @patch("src.init_job.repackage._clone_repo")
     @patch("src.init_job.repackage._fetch_ssm_values")
     @patch("src.init_job.repackage._fetch_secret_values")
     @patch("src.init_job.repackage.s3_ops.generate_callback_presigned_url")
     @patch("src.init_job.repackage.OrderBundler")
-    def test_multiple_orders(
+    def test_multiple_orders_same_repo_clones_once(
         self, MockBundler, mock_presign, mock_secrets,
-        mock_ssm, mock_git,
+        mock_ssm, mock_clone,
     ):
-        with tempfile.TemporaryDirectory() as code_dir:
-            mock_git.return_value = code_dir
+        with tempfile.TemporaryDirectory() as clone_dir:
+            mock_clone.return_value = clone_dir
             mock_ssm.return_value = {}
             mock_secrets.return_value = {}
             mock_presign.return_value = "https://presigned.url"
             MockBundler.return_value = MagicMock()
 
-            with open(os.path.join(code_dir, "f.txt"), "w") as f:
-                f.write("x")
+            # Create folder structure in clone
+            os.makedirs(os.path.join(clone_dir, "vpc"), exist_ok=True)
+            os.makedirs(os.path.join(clone_dir, "rds"), exist_ok=True)
+            with open(os.path.join(clone_dir, "vpc", "main.tf"), "w") as f:
+                f.write("vpc")
+            with open(os.path.join(clone_dir, "rds", "main.tf"), "w") as f:
+                f.write("rds")
 
             job = _make_job(orders=[
-                _make_order(order_name="order-a"),
-                _make_order(order_name="order-b"),
+                _make_order(order_name="order-a", git_folder="vpc"),
+                _make_order(order_name="order-b", git_folder="rds"),
             ])
 
             results = repackage_orders(
@@ -169,3 +279,139 @@ class TestRepackageOrders:
             assert len(results) == 2
             assert results[0]["order_num"] == "0001"
             assert results[1]["order_num"] == "0002"
+
+            # KEY: only one clone despite two orders
+            mock_clone.assert_called_once()
+
+    @patch("src.init_job.repackage._clone_repo")
+    @patch("src.init_job.repackage._fetch_ssm_values")
+    @patch("src.init_job.repackage._fetch_secret_values")
+    @patch("src.init_job.repackage.s3_ops.generate_callback_presigned_url")
+    @patch("src.init_job.repackage.OrderBundler")
+    def test_different_repos_clone_separately(
+        self, MockBundler, mock_presign, mock_secrets,
+        mock_ssm, mock_clone,
+    ):
+        created_dirs = []
+
+        def clone_side_effect(repo, token_location, commit_hash=None, ssh_key_location=None):
+            d = tempfile.mkdtemp(prefix="iac-ci-test-")
+            with open(os.path.join(d, "main.tf"), "w") as f:
+                f.write(f"repo={repo}")
+            created_dirs.append(d)
+            return d
+
+        mock_clone.side_effect = clone_side_effect
+        mock_ssm.return_value = {}
+        mock_secrets.return_value = {}
+        mock_presign.return_value = "https://presigned.url"
+        MockBundler.return_value = MagicMock()
+
+        job = _make_job(orders=[
+            _make_order(order_name="order-a", git_repo="org/repo-a"),
+            _make_order(order_name="order-b", git_repo="org/repo-b"),
+        ])
+
+        results = repackage_orders(
+            job=job,
+            run_id="run-1",
+            trace_id="abc",
+            flow_id="user:abc-exec",
+            internal_bucket="bucket",
+        )
+
+        assert len(results) == 2
+        # Two different repos => two clones
+        assert mock_clone.call_count == 2
+
+        for d in created_dirs:
+            shutil.rmtree(d, ignore_errors=True)
+
+    @patch("src.init_job.repackage._clone_repo")
+    @patch("src.init_job.repackage._fetch_ssm_values")
+    @patch("src.init_job.repackage._fetch_secret_values")
+    @patch("src.init_job.repackage.s3_ops.generate_callback_presigned_url")
+    @patch("src.init_job.repackage.OrderBundler")
+    def test_same_repo_different_commits_clone_separately(
+        self, MockBundler, mock_presign, mock_secrets,
+        mock_ssm, mock_clone,
+    ):
+        created_dirs = []
+
+        def clone_side_effect(repo, token_location, commit_hash=None, ssh_key_location=None):
+            d = tempfile.mkdtemp(prefix="iac-ci-test-")
+            with open(os.path.join(d, "main.tf"), "w") as f:
+                f.write(f"commit={commit_hash}")
+            created_dirs.append(d)
+            return d
+
+        mock_clone.side_effect = clone_side_effect
+        mock_ssm.return_value = {}
+        mock_secrets.return_value = {}
+        mock_presign.return_value = "https://presigned.url"
+        MockBundler.return_value = MagicMock()
+
+        job = _make_job(orders=[
+            _make_order(order_name="order-a", commit_hash="abc123"),
+            _make_order(order_name="order-b", commit_hash="def456"),
+        ])
+
+        results = repackage_orders(
+            job=job,
+            run_id="run-1",
+            trace_id="abc",
+            flow_id="user:abc-exec",
+            internal_bucket="bucket",
+        )
+
+        assert len(results) == 2
+        # Same repo, different commits => two clones
+        assert mock_clone.call_count == 2
+
+        for d in created_dirs:
+            shutil.rmtree(d, ignore_errors=True)
+
+    @patch("src.init_job.repackage._clone_repo")
+    @patch("src.init_job.repackage._fetch_ssm_values")
+    @patch("src.init_job.repackage._fetch_secret_values")
+    @patch("src.init_job.repackage.s3_ops.generate_callback_presigned_url")
+    @patch("src.init_job.repackage.OrderBundler")
+    def test_job_level_commit_hash_groups_orders(
+        self, MockBundler, mock_presign, mock_secrets,
+        mock_ssm, mock_clone,
+    ):
+        with tempfile.TemporaryDirectory() as clone_dir:
+            mock_clone.return_value = clone_dir
+            mock_ssm.return_value = {}
+            mock_secrets.return_value = {}
+            mock_presign.return_value = "https://presigned.url"
+            MockBundler.return_value = MagicMock()
+
+            os.makedirs(os.path.join(clone_dir, "vpc"), exist_ok=True)
+            os.makedirs(os.path.join(clone_dir, "rds"), exist_ok=True)
+            with open(os.path.join(clone_dir, "vpc", "main.tf"), "w") as f:
+                f.write("vpc")
+            with open(os.path.join(clone_dir, "rds", "main.tf"), "w") as f:
+                f.write("rds")
+
+            job = _make_job(
+                commit_hash="abc123",
+                orders=[
+                    _make_order(order_name="order-a", git_folder="vpc"),
+                    _make_order(order_name="order-b", git_folder="rds"),
+                ],
+            )
+
+            results = repackage_orders(
+                job=job,
+                run_id="run-1",
+                trace_id="abc",
+                flow_id="user:abc-exec",
+                internal_bucket="bucket",
+            )
+
+            assert len(results) == 2
+            # Same repo + same job-level commit => single clone
+            mock_clone.assert_called_once()
+            call_kwargs = mock_clone.call_args
+            assert call_kwargs[1]["commit_hash"] == "abc123"


### PR DESCRIPTION
Group git-sourced orders by (git_repo, commit_hash) during repackage to avoid redundant clones. Orders sharing the same repo+commit now share a single shallow clone, with each order's git_folder copied into an isolated temp directory for bundling.

- Add commit_hash field to Order and Job models
- Replace _fetch_code_git with _clone_repo, _extract_folder, _group_git_orders, and _process_order helpers
- Include commit_hash in git_b64 metadata stored in DynamoDB
- Add comprehensive tests for grouping, folder extraction, and clone-count verification

https://claude.ai/code/session_018ZyiWTgpYmESeJUbHstnyp