### PR TITLE
Add SSM config provider for server configuration via SSM Run Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # iac-ci
 
-Event-driven execution engine for infrastructure-as-code, built on AWS Lambda, CodeBuild, DynamoDB, S3, Step Functions, and API Gateway.
+Event-driven execution engine for infrastructure-as-code, built on AWS Lambda, CodeBuild, SSM Run Command, DynamoDB, S3, Step Functions, and API Gateway.
 
 ## Overview
 
-iac-ci receives jobs containing orders (shell commands) via a webhook, queues them in DynamoDB, and executes them through Lambda or CodeBuild with full dependency resolution. It handles cross-account AWS credentials via SOPS encryption and tracks progress through VCS PR comments.
+iac-ci receives jobs containing orders (shell commands) via a webhook, queues them in DynamoDB, and executes them through Lambda, CodeBuild, or SSM Run Command with full dependency resolution. It handles cross-account AWS credentials via SOPS encryption (Lambda/CodeBuild) or SSM command parameters (SSM) and tracks progress through VCS PR comments.
 
 The system works in two phases:
 
-1. **Webhook intake** -- validates orders, packages credentials with SOPS, uploads execution bundles to S3, inserts state into DynamoDB, and posts an initial PR comment.
-2. **Orchestrator execution** -- triggered by S3 callback events, resolves dependency graphs, dispatches ready orders in parallel to Lambda or CodeBuild, and finalizes when all orders complete.
+1. **Webhook intake** -- validates orders, packages credentials with SOPS (or plain env vars for SSM), uploads execution bundles to S3, inserts state into DynamoDB, and posts an initial PR comment. Two entry points: `POST /webhook` for Lambda/CodeBuild orders, `POST /ssm` for SSM Run Command orders.
+2. **Orchestrator execution** -- triggered by S3 callback events, resolves dependency graphs, dispatches ready orders in parallel to Lambda, CodeBuild, or SSM Run Command, and finalizes when all orders complete.
 
 Everything is serverless. Nothing runs 24/7. All working data auto-cleans via TTL and lifecycle rules.
 
@@ -23,10 +23,11 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full system design.
 | S3 bucket (internal) | `iac-ci-internal-<hash>` | Exec bundles + callbacks, 1-day lifecycle |
 | S3 bucket (done) | `iac-ci-done-<hash>` | Completion markers, 1-day lifecycle |
 | ECR repository | `iac-ci` | Single Docker image for all functions |
-| Lambda functions (x4) | `iac-ci-init-job`, `iac-ci-orchestrator`, `iac-ci-watchdog-check`, `iac-ci-worker` | Same image, different entrypoints |
-| API Gateway (HTTP) | `iac-ci` | POST /webhook |
+| Lambda functions (x5) | `iac-ci-init-job`, `iac-ci-orchestrator`, `iac-ci-watchdog-check`, `iac-ci-worker`, `iac-ci-ssm-config` | Same image, different entrypoints |
+| API Gateway (HTTP) | `iac-ci` | POST /webhook, POST /ssm |
 | DynamoDB tables (x3) | `iac-ci-orders`, `iac-ci-order-events`, `iac-ci-locks` | PAY_PER_REQUEST billing |
 | CodeBuild project | `iac-ci-worker` | For long-running orders |
+| SSM Document | `iac-ci-run-commands` | For SSM Run Command orders |
 | Step Function | `iac-ci-watchdog` | Per-order timeout safety |
 | IAM roles | `iac-ci-*` | Least-privilege per function |
 

--- a/infra/02-deploy/api_gateway.tf
+++ b/infra/02-deploy/api_gateway.tf
@@ -29,3 +29,26 @@ resource "aws_lambda_permission" "apigw_invoke" {
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_apigatewayv2_api.webhook.execution_arn}/*/*"
 }
+
+# --- SSM config route ---
+
+resource "aws_apigatewayv2_integration" "ssm_config" {
+  api_id                 = aws_apigatewayv2_api.webhook.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.ssm_config.invoke_arn
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "post_ssm" {
+  api_id    = aws_apigatewayv2_api.webhook.id
+  route_key = "POST /ssm"
+  target    = "integrations/${aws_apigatewayv2_integration.ssm_config.id}"
+}
+
+resource "aws_lambda_permission" "apigw_ssm_config" {
+  statement_id  = "AllowAPIGatewayInvokeSSM"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.ssm_config.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.webhook.execution_arn}/*/*"
+}

--- a/infra/02-deploy/lambdas.tf
+++ b/infra/02-deploy/lambdas.tf
@@ -51,6 +51,7 @@ resource "aws_lambda_function" "orchestrator" {
       IAC_CI_WORKER_LAMBDA     = "iac-ci-worker"
       IAC_CI_CODEBUILD_PROJECT = aws_codebuild_project.worker.name
       IAC_CI_WATCHDOG_SFN      = aws_sfn_state_machine.watchdog.arn
+      IAC_CI_SSM_DOCUMENT      = aws_ssm_document.run_commands.name
     })
   }
 }
@@ -86,6 +87,25 @@ resource "aws_lambda_function" "worker" {
 
   image_config {
     command = ["src.worker.handler.handler"]
+  }
+
+  environment {
+    variables = local.lambda_env
+  }
+}
+
+# --- ssm_config ---
+
+resource "aws_lambda_function" "ssm_config" {
+  function_name = "iac-ci-ssm-config"
+  role          = aws_iam_role.ssm_config.arn
+  package_type  = "Image"
+  image_uri     = local.image_uri
+  timeout       = 300
+  memory_size   = 512
+
+  image_config {
+    command = ["src.ssm_config.handler.handler"]
   }
 
   environment {

--- a/infra/02-deploy/outputs.tf
+++ b/infra/02-deploy/outputs.tf
@@ -15,6 +15,7 @@ output "lambda_function_names" {
     orchestrator    = aws_lambda_function.orchestrator.function_name
     watchdog_check  = aws_lambda_function.watchdog_check.function_name
     worker          = aws_lambda_function.worker.function_name
+    ssm_config      = aws_lambda_function.ssm_config.function_name
   }
 }
 
@@ -25,6 +26,7 @@ output "lambda_function_arns" {
     orchestrator    = aws_lambda_function.orchestrator.arn
     watchdog_check  = aws_lambda_function.watchdog_check.arn
     worker          = aws_lambda_function.worker.arn
+    ssm_config      = aws_lambda_function.ssm_config.arn
   }
 }
 
@@ -53,4 +55,9 @@ output "step_function_arn" {
 output "codebuild_project_name" {
   description = "CodeBuild project name"
   value       = aws_codebuild_project.worker.name
+}
+
+output "ssm_document_name" {
+  description = "SSM Document name for command execution"
+  value       = aws_ssm_document.run_commands.name
 }

--- a/infra/02-deploy/ssm_document.tf
+++ b/infra/02-deploy/ssm_document.tf
@@ -1,0 +1,119 @@
+resource "aws_ssm_document" "run_commands" {
+  name            = "iac-ci-run-commands"
+  document_type   = "Command"
+  document_format = "YAML"
+
+  content = yamlencode({
+    schemaVersion = "2.2"
+    description   = "iac-ci generic command runner — downloads code from S3, runs commands, sends callback"
+    parameters = {
+      Commands = {
+        type        = "String"
+        description = "JSON array of shell commands to execute"
+      }
+      CallbackUrl = {
+        type        = "String"
+        description = "Presigned S3 PUT URL for result callback"
+      }
+      Timeout = {
+        type        = "String"
+        description = "Timeout in seconds"
+        default     = "300"
+      }
+      EnvVars = {
+        type        = "String"
+        description = "JSON object of environment variables to set"
+        default     = "{}"
+      }
+      S3Location = {
+        type        = "String"
+        description = "S3 URI for exec.zip (optional)"
+        default     = ""
+      }
+    }
+    mainSteps = [
+      {
+        action = "aws:runShellScript"
+        name   = "runCommands"
+        inputs = {
+          timeoutSeconds = "{{ Timeout }}"
+          runCommand = [
+            "#!/bin/bash",
+            "set -o pipefail",
+            "",
+            "WORK_DIR=$(mktemp -d /tmp/iac-ci-XXXXXX)",
+            "cd \"$WORK_DIR\"",
+            "STATUS=succeeded",
+            "LOG_FILE=$(mktemp)",
+            "",
+            "# Export environment variables from EnvVars JSON",
+            "ENV_VARS='{{ EnvVars }}'",
+            "if [ \"$ENV_VARS\" != '{}' ] && command -v python3 &>/dev/null; then",
+            "  eval $(python3 -c \"",
+            "import json, sys, shlex",
+            "d = json.loads(sys.argv[1])",
+            "for k, v in d.items():",
+            "    print(f'export {k}={shlex.quote(str(v))}')",
+            "\" \"$ENV_VARS\")",
+            "fi",
+            "",
+            "# Download and extract exec.zip if S3 location provided",
+            "S3_LOC='{{ S3Location }}'",
+            "if [ -n \"$S3_LOC\" ]; then",
+            "  aws s3 cp \"$S3_LOC\" exec.zip >> $LOG_FILE 2>&1",
+            "  unzip -o exec.zip >> $LOG_FILE 2>&1",
+            "  rm -f exec.zip",
+            "fi",
+            "",
+            "# Execute commands sequentially",
+            "CMDS='{{ Commands }}'",
+            "python3 -c \"",
+            "import json, subprocess, sys, os",
+            "cmds = json.loads(sys.argv[1])",
+            "log_file = sys.argv[2]",
+            "work_dir = sys.argv[3]",
+            "status = 'succeeded'",
+            "for cmd in cmds:",
+            "    with open(log_file, 'a') as lf:",
+            "        lf.write(f'\\$ {cmd}\\n')",
+            "    rc = subprocess.call(cmd, shell=True, cwd=work_dir,",
+            "        stdout=open(log_file, 'a'), stderr=subprocess.STDOUT)",
+            "    if rc != 0:",
+            "        with open(log_file, 'a') as lf:",
+            "            lf.write(f'Exit code: {rc}\\n')",
+            "        status = 'failed'",
+            "        break",
+            "with open(os.path.join(work_dir, '.status'), 'w') as f:",
+            "    f.write(status)",
+            "\" \"$CMDS\" \"$LOG_FILE\" \"$WORK_DIR\"",
+            "",
+            "# Read status",
+            "if [ -f \"$WORK_DIR/.status\" ]; then",
+            "  STATUS=$(cat \"$WORK_DIR/.status\")",
+            "else",
+            "  STATUS=failed",
+            "fi",
+            "",
+            "# Send callback via presigned URL",
+            "CALLBACK_URL='{{ CallbackUrl }}'",
+            "if [ -n \"$CALLBACK_URL\" ]; then",
+            "  PAYLOAD=$(python3 -c \"",
+            "import json, sys",
+            "status = sys.argv[1]",
+            "log = open(sys.argv[2]).read()[:262144]",
+            "print(json.dumps({'status': status, 'log': log}))",
+            "\" \"$STATUS\" \"$LOG_FILE\")",
+            "  curl -s -X PUT -H 'Content-Type: application/json' \\",
+            "    -d \"$PAYLOAD\" \"$CALLBACK_URL\" || true",
+            "fi",
+            "",
+            "# Cleanup",
+            "rm -rf \"$WORK_DIR\" \"$LOG_FILE\"",
+            "",
+            "if [ \"$STATUS\" = 'failed' ]; then exit 1; fi",
+          ]
+        }
+      }
+    ]
+  })
+}

--- a/src/common/code_source.py
+++ b/src/common/code_source.py
@@ -1,0 +1,142 @@
+"""Shared code source operations — git clone, S3 fetch, credential retrieval, zip."""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import zipfile
+from typing import Dict, List, Optional, Tuple
+
+import boto3
+
+
+def fetch_ssm_values(paths: List[str], region: Optional[str] = None) -> Dict[str, str]:
+    """Fetch values from AWS SSM Parameter Store."""
+    if not paths:
+        return {}
+    client = boto3.client("ssm", region_name=region)
+    result = {}
+    for path in paths:
+        resp = client.get_parameter(Name=path, WithDecryption=True)
+        # Use the last segment of the path as the env var name
+        key = path.rsplit("/", 1)[-1].upper().replace("-", "_")
+        result[key] = resp["Parameter"]["Value"]
+    return result
+
+
+def fetch_secret_values(paths: List[str], region: Optional[str] = None) -> Dict[str, str]:
+    """Fetch values from AWS Secrets Manager."""
+    if not paths:
+        return {}
+    client = boto3.client("secretsmanager", region_name=region)
+    result = {}
+    for path in paths:
+        resp = client.get_secret_value(SecretId=path)
+        key = path.rsplit("/", 1)[-1].upper().replace("-", "_")
+        result[key] = resp["SecretString"]
+    return result
+
+
+def clone_repo(
+    repo: str,
+    token_location: str,
+    commit_hash: Optional[str] = None,
+    ssh_key_location: Optional[str] = None,
+) -> str:
+    """Clone a git repo and optionally checkout a specific commit.
+
+    Returns the path to the repository root directory.
+    Uses --depth 1 for HEAD, --depth 2 when a specific commit_hash is requested.
+    """
+    work_dir = tempfile.mkdtemp(prefix="iac-ci-git-")
+    clone_url = f"https://github.com/{repo}.git"
+
+    depth = "2" if commit_hash else "1"
+    subprocess.run(
+        ["git", "clone", "--depth", depth, clone_url, work_dir],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    if commit_hash:
+        subprocess.run(
+            ["git", "checkout", commit_hash],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=work_dir,
+        )
+
+    return work_dir
+
+
+def extract_folder(clone_dir: str, folder: Optional[str] = None) -> str:
+    """Copy a folder (or the entire repo) from a shared clone into an isolated temp dir.
+
+    Each order needs its own copy because OrderBundler writes files in-place.
+    Excludes .git directory to save space.
+    """
+    source = os.path.join(clone_dir, folder) if folder else clone_dir
+    if not os.path.isdir(source):
+        raise FileNotFoundError(
+            f"Folder '{folder}' not found in cloned repo at {clone_dir}"
+        )
+    isolated_dir = tempfile.mkdtemp(prefix="iac-ci-order-")
+    shutil.copytree(source, isolated_dir, dirs_exist_ok=True,
+                    ignore=shutil.ignore_patterns(".git"))
+    return isolated_dir
+
+
+def group_git_orders(
+    orders,
+    job,
+) -> Tuple[Dict[Tuple[str, Optional[str]], list], List[int]]:
+    """Group git-sourced orders by (repo, commit_hash).
+
+    Returns:
+        git_groups: dict mapping (repo, commit_hash) -> list of (order_index, order)
+        s3_indices: list of order indices that use S3 source
+    """
+    git_groups: Dict[Tuple[str, Optional[str]], list] = {}
+    s3_indices: List[int] = []
+
+    for i, order in enumerate(orders):
+        if getattr(order, "s3_location", None):
+            s3_indices.append(i)
+        else:
+            repo = getattr(order, "git_repo", None) or getattr(job, "git_repo", None) or ""
+            commit = getattr(order, "commit_hash", None) or getattr(job, "commit_hash", None)
+            key = (repo, commit)
+            git_groups.setdefault(key, []).append((i, order))
+
+    return git_groups, s3_indices
+
+
+def fetch_code_s3(s3_location: str) -> str:
+    """Download and extract a zip from S3. Returns path to extracted directory."""
+    work_dir = tempfile.mkdtemp(prefix="iac-ci-s3-")
+    # Parse s3://bucket/key
+    parts = s3_location.replace("s3://", "").split("/", 1)
+    bucket = parts[0]
+    key = parts[1] if len(parts) > 1 else ""
+
+    local_zip = os.path.join(work_dir, "code.zip")
+    s3_client = boto3.client("s3")
+    s3_client.download_file(bucket, key, local_zip)
+
+    with zipfile.ZipFile(local_zip, "r") as zf:
+        zf.extractall(work_dir)
+    os.unlink(local_zip)
+    return work_dir
+
+
+def zip_directory(code_dir: str, output_path: str) -> str:
+    """Zip a directory into output_path."""
+    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for root, dirs, files in os.walk(code_dir):
+            for f in files:
+                full_path = os.path.join(root, f)
+                arcname = os.path.relpath(full_path, code_dir)
+                zf.write(full_path, arcname)
+    return output_path

--- a/src/init_job/upload.py
+++ b/src/init_job/upload.py
@@ -15,6 +15,8 @@ def upload_orders(
     Expected path: tmp/exec/<run_id>/<order_num>/exec.zip
     """
     for order_info in repackaged_orders:
+        if order_info.get("zip_path") is None:
+            continue
         s3_ops.upload_exec_zip(
             bucket=bucket,
             run_id=run_id,

--- a/src/init_job/validate.py
+++ b/src/init_job/validate.py
@@ -2,7 +2,7 @@
 
 from typing import List
 
-from src.common.models import Job
+from src.common.models import EXECUTION_TARGETS, Job
 
 
 def validate_orders(job: Job) -> List[str]:
@@ -23,6 +23,11 @@ def validate_orders(job: Job) -> List[str]:
         # timeout must be present and positive
         if not order.timeout or order.timeout <= 0:
             return [f"{order_label}: timeout is missing or invalid"]
+
+        # execution_target must be valid
+        if order.execution_target not in EXECUTION_TARGETS:
+            return [f"{order_label}: invalid execution_target '{order.execution_target}' "
+                    f"(must be one of {sorted(EXECUTION_TARGETS)})"]
 
         # Must have a code source: s3_location OR (git_repo + git_token_location from job)
         has_s3 = bool(order.s3_location)

--- a/src/ssm_config/handler.py
+++ b/src/ssm_config/handler.py
@@ -1,0 +1,164 @@
+"""Lambda entrypoint for ssm_config — SSM config provider.
+
+Separate construction point for SSM orders. Packages code, fetches credentials
+(no SOPS), uploads to S3, inserts into shared DynamoDB orders table, and
+triggers the orchestrator.
+
+Supports three invocation sources:
+  - Direct Lambda invoke: {"job_parameters_b64": "..."}
+  - SNS trigger: {"Records": [{"Sns": {"Message": "{...}"}}]}
+  - API Gateway: {"httpMethod": "POST", "body": "{...}"}
+"""
+
+import json
+import logging
+import os
+import uuid
+from typing import Any, Dict
+
+from src.common.trace import generate_trace_id, create_leg
+from src.common.flow import generate_flow_id
+from src.common import s3 as s3_ops
+from src.ssm_config.models import SsmJob
+from src.ssm_config.validate import validate_ssm_orders
+from src.ssm_config.repackage import repackage_ssm_orders
+from src.ssm_config.insert import insert_ssm_orders
+from src.init_job.upload import upload_orders
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_event(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract the job payload from any supported invocation source."""
+    # SNS
+    if "Records" in event:
+        records = event["Records"]
+        if records and "Sns" in records[0]:
+            message = records[0]["Sns"].get("Message", "{}")
+            if isinstance(message, str):
+                return json.loads(message)
+            return message
+
+    # API Gateway
+    if "httpMethod" in event:
+        if event["httpMethod"] != "POST":
+            return {"_apigw_error": f"Method {event['httpMethod']} not allowed"}
+        body = event.get("body", "")
+        if isinstance(body, str):
+            return json.loads(body) if body else {}
+        return body if isinstance(body, dict) else {}
+
+    return event
+
+
+def process_ssm_job(
+    job_parameters_b64: str,
+    trace_id: str = "",
+    run_id: str = "",
+    done_endpt: str = "",
+) -> dict:
+    """Main processing function for SSM config provider."""
+    internal_bucket = os.environ.get("IAC_CI_INTERNAL_BUCKET", "")
+    done_bucket = os.environ.get("IAC_CI_DONE_BUCKET", "")
+
+    job = SsmJob.from_b64(job_parameters_b64)
+
+    if not trace_id:
+        trace_id = generate_trace_id()
+    if not run_id:
+        run_id = str(uuid.uuid4())
+
+    flow_id = generate_flow_id(job.username, trace_id, job.flow_label)
+
+    if not done_endpt:
+        done_endpt = f"s3://{done_bucket}/{run_id}/done"
+
+    # Step 1: Validate
+    errors = validate_ssm_orders(job)
+    if errors:
+        return {
+            "status": "error",
+            "errors": errors,
+            "run_id": run_id,
+            "trace_id": trace_id,
+        }
+
+    # Step 2: Repackage (no SOPS)
+    leg = create_leg(trace_id)
+    repackaged = repackage_ssm_orders(
+        job=job,
+        run_id=run_id,
+        trace_id=trace_id,
+        flow_id=flow_id,
+        internal_bucket=internal_bucket,
+    )
+
+    # Step 3: Upload
+    upload_orders(repackaged, run_id, internal_bucket)
+
+    # Step 4: Insert into DynamoDB
+    insert_ssm_orders(
+        job=job,
+        run_id=run_id,
+        flow_id=flow_id,
+        trace_id=trace_id,
+        repackaged_orders=repackaged,
+        internal_bucket=internal_bucket,
+    )
+
+    # Step 5: Write init trigger to kick off orchestrator
+    s3_ops.write_init_trigger(
+        bucket=internal_bucket,
+        run_id=run_id,
+    )
+
+    return {
+        "status": "ok",
+        "run_id": run_id,
+        "trace_id": trace_id,
+        "flow_id": flow_id,
+        "done_endpt": done_endpt,
+    }
+
+
+def _apigw_response(status_code: int, body: dict) -> dict:
+    """Wrap result in API Gateway proxy response format."""
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(body),
+    }
+
+
+def handler(event: Dict[str, Any], context: Any = None) -> dict:
+    """Lambda entrypoint. Supports direct invoke, SNS, and API Gateway."""
+    is_apigw = "httpMethod" in event
+
+    try:
+        payload = _normalize_event(event)
+
+        if "_apigw_error" in payload:
+            return _apigw_response(405, {"status": "error", "error": payload["_apigw_error"]})
+
+        job_parameters_b64 = payload.get("job_parameters_b64", "")
+
+        if not job_parameters_b64:
+            result = {"status": "error", "error": "Missing job_parameters_b64"}
+            return _apigw_response(400, result) if is_apigw else result
+
+        result = process_ssm_job(
+            job_parameters_b64=job_parameters_b64,
+            trace_id=payload.get("trace_id", ""),
+            run_id=payload.get("run_id", ""),
+            done_endpt=payload.get("done_endpt", ""),
+        )
+
+        if is_apigw:
+            code = 200 if result.get("status") == "ok" else 400
+            return _apigw_response(code, result)
+        return result
+
+    except Exception as e:
+        logger.exception("ssm_config failed")
+        result = {"status": "error", "error": str(e)}
+        return _apigw_response(500, result) if is_apigw else result

--- a/src/ssm_config/models.py
+++ b/src/ssm_config/models.py
@@ -1,0 +1,73 @@
+"""Data models for SSM config provider."""
+
+import base64
+import json
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class SsmOrder:
+    """Per-order fields for SSM execution."""
+
+    cmds: List[str]
+    timeout: int
+    ssm_targets: Dict[str, Any]
+    order_name: Optional[str] = None
+    git_repo: Optional[str] = None
+    git_folder: Optional[str] = None
+    commit_hash: Optional[str] = None
+    s3_location: Optional[str] = None
+    env_vars: Optional[Dict[str, str]] = None
+    ssm_paths: Optional[List[str]] = None
+    secret_manager_paths: Optional[List[str]] = None
+    ssm_document_name: Optional[str] = None
+    queue_id: Optional[str] = None
+    dependencies: Optional[List[str]] = None
+    must_succeed: bool = True
+    callback_url: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SsmOrder":
+        known_fields = {f.name for f in cls.__dataclass_fields__.values()}
+        filtered = {k: v for k, v in data.items() if k in known_fields}
+        return cls(**filtered)
+
+
+@dataclass
+class SsmJob:
+    """Job-level fields for SSM config provider."""
+
+    username: str
+    orders: List[SsmOrder]
+    git_repo: Optional[str] = None
+    git_token_location: Optional[str] = None
+    git_ssh_key_location: Optional[str] = None
+    commit_hash: Optional[str] = None
+    flow_label: str = "ssm"
+    presign_expiry: int = 7200
+    job_timeout: int = 3600
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["orders"] = [o.to_dict() for o in self.orders]
+        return {k: v for k, v in d.items() if v is not None}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SsmJob":
+        orders_data = data.get("orders", [])
+        orders = [SsmOrder.from_dict(o) for o in orders_data]
+        known_fields = {f.name for f in cls.__dataclass_fields__.values()}
+        filtered = {k: v for k, v in data.items() if k in known_fields and k != "orders"}
+        return cls(orders=orders, **filtered)
+
+    def to_b64(self) -> str:
+        return base64.b64encode(json.dumps(self.to_dict()).encode()).decode()
+
+    @classmethod
+    def from_b64(cls, b64_str: str) -> "SsmJob":
+        data = json.loads(base64.b64decode(b64_str).decode())
+        return cls.from_dict(data)

--- a/src/ssm_config/validate.py
+++ b/src/ssm_config/validate.py
@@ -1,0 +1,37 @@
+"""Validate SSM orders before processing."""
+
+from typing import List
+
+from src.ssm_config.models import SsmJob
+
+
+def validate_ssm_orders(job: SsmJob) -> List[str]:
+    """Validate all SSM orders in a job. Returns list of errors (empty if valid).
+
+    Fail-fast: returns on the first invalid order.
+    """
+    if not job.orders:
+        return ["Job has no orders"]
+
+    for i, order in enumerate(job.orders):
+        order_label = order.order_name or f"order[{i}]"
+
+        # cmds must exist and be non-empty
+        if not order.cmds:
+            return [f"{order_label}: cmds is empty or missing"]
+
+        # timeout must be present and positive
+        if not order.timeout or order.timeout <= 0:
+            return [f"{order_label}: timeout is missing or invalid"]
+
+        # ssm_targets is required
+        if not order.ssm_targets:
+            return [f"{order_label}: ssm_targets is required for SSM orders"]
+
+        # ssm_targets must contain instance_ids or tags
+        has_ids = bool(order.ssm_targets.get("instance_ids"))
+        has_tags = bool(order.ssm_targets.get("tags"))
+        if not has_ids and not has_tags:
+            return [f"{order_label}: ssm_targets must contain 'instance_ids' or 'tags'"]
+
+    return []

--- a/tests/unit/test_ssm_config_handler.py
+++ b/tests/unit/test_ssm_config_handler.py
@@ -1,0 +1,165 @@
+"""Unit tests for src/ssm_config/handler.py."""
+
+import base64
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from src.ssm_config.models import SsmJob, SsmOrder
+from src.ssm_config.handler import handler, process_ssm_job, _normalize_event
+
+
+def _make_ssm_job_b64(**kwargs):
+    defaults = {
+        "username": "testuser",
+        "orders": [
+            {
+                "cmds": ["echo hi"],
+                "timeout": 300,
+                "ssm_targets": {"instance_ids": ["i-abc123"]},
+            },
+        ],
+    }
+    defaults.update(kwargs)
+    return base64.b64encode(json.dumps(defaults).encode()).decode()
+
+
+# ── _normalize_event ──────────────────────────────────────────────
+
+class TestNormalizeEvent:
+    def test_direct_invoke_passthrough(self):
+        event = {"job_parameters_b64": "abc", "trace_id": "t1"}
+        assert _normalize_event(event) == event
+
+    def test_apigw_post_unwraps_body(self):
+        payload = {"job_parameters_b64": "abc"}
+        event = {"httpMethod": "POST", "body": json.dumps(payload)}
+        assert _normalize_event(event) == payload
+
+    def test_apigw_dict_body(self):
+        payload = {"job_parameters_b64": "abc"}
+        event = {"httpMethod": "POST", "body": payload}
+        assert _normalize_event(event) == payload
+
+    def test_apigw_non_post_rejected(self):
+        event = {"httpMethod": "GET", "body": "{}"}
+        result = _normalize_event(event)
+        assert "_apigw_error" in result
+        assert "GET" in result["_apigw_error"]
+
+    def test_apigw_put_rejected(self):
+        event = {"httpMethod": "PUT", "body": "{}"}
+        result = _normalize_event(event)
+        assert "_apigw_error" in result
+        assert "PUT" in result["_apigw_error"]
+
+    def test_apigw_empty_body(self):
+        event = {"httpMethod": "POST", "body": ""}
+        assert _normalize_event(event) == {}
+
+    def test_sns_unwraps_message(self):
+        payload = {"job_parameters_b64": "abc"}
+        event = {"Records": [{"Sns": {"Message": json.dumps(payload)}}]}
+        assert _normalize_event(event) == payload
+
+    def test_sns_dict_message(self):
+        payload = {"job_parameters_b64": "abc"}
+        event = {"Records": [{"Sns": {"Message": payload}}]}
+        assert _normalize_event(event) == payload
+
+
+# ── handler (direct invoke) ──────────────────────────────────────
+
+class TestHandlerDirectInvoke:
+    def test_missing_job_parameters_returns_error(self):
+        resp = handler({})
+        assert resp["status"] == "error"
+        assert "Missing" in resp["error"]
+        assert "statusCode" not in resp  # not wrapped in APIGW format
+
+    @patch("src.ssm_config.handler.process_ssm_job")
+    def test_valid_request_returns_ok(self, mock_process):
+        mock_process.return_value = {
+            "status": "ok",
+            "run_id": "run-1",
+            "trace_id": "abc",
+            "flow_id": "user:abc-ssm",
+            "done_endpt": "s3://done/run-1/done",
+        }
+
+        event = {"job_parameters_b64": _make_ssm_job_b64()}
+        resp = handler(event)
+        assert resp["status"] == "ok"
+        assert resp["run_id"] == "run-1"
+        assert "statusCode" not in resp
+
+    @patch("src.ssm_config.handler.process_ssm_job")
+    def test_exception_returns_error(self, mock_process):
+        mock_process.side_effect = RuntimeError("boom")
+
+        resp = handler({"job_parameters_b64": _make_ssm_job_b64()})
+        assert resp["status"] == "error"
+        assert "boom" in resp["error"]
+        assert "statusCode" not in resp
+
+
+# ── handler (API Gateway) ────────────────────────────────────────
+
+class TestHandlerAPIGateway:
+    @patch("src.ssm_config.handler.process_ssm_job")
+    def test_apigw_post_returns_200(self, mock_process):
+        mock_process.return_value = {"status": "ok", "run_id": "r1"}
+
+        payload = {"job_parameters_b64": _make_ssm_job_b64()}
+        event = {"httpMethod": "POST", "body": json.dumps(payload)}
+        resp = handler(event)
+        assert resp["statusCode"] == 200
+        body = json.loads(resp["body"])
+        assert body["status"] == "ok"
+
+    def test_apigw_get_returns_405(self):
+        event = {"httpMethod": "GET", "body": "{}"}
+        resp = handler(event)
+        assert resp["statusCode"] == 405
+
+    def test_apigw_missing_payload_returns_400(self):
+        event = {"httpMethod": "POST", "body": "{}"}
+        resp = handler(event)
+        assert resp["statusCode"] == 400
+        body = json.loads(resp["body"])
+        assert "Missing" in body["error"]
+
+    @patch("src.ssm_config.handler.process_ssm_job")
+    def test_apigw_error_returns_400(self, mock_process):
+        mock_process.return_value = {"status": "error", "errors": ["bad order"]}
+
+        payload = {"job_parameters_b64": _make_ssm_job_b64()}
+        event = {"httpMethod": "POST", "body": json.dumps(payload)}
+        resp = handler(event)
+        assert resp["statusCode"] == 400
+
+    @patch("src.ssm_config.handler.process_ssm_job")
+    def test_apigw_exception_returns_500(self, mock_process):
+        mock_process.side_effect = RuntimeError("crash")
+
+        payload = {"job_parameters_b64": _make_ssm_job_b64()}
+        event = {"httpMethod": "POST", "body": json.dumps(payload)}
+        resp = handler(event)
+        assert resp["statusCode"] == 500
+        body = json.loads(resp["body"])
+        assert "crash" in body["error"]
+
+
+# ── handler (SNS) ────────────────────────────────────────────────
+
+class TestHandlerSNS:
+    @patch("src.ssm_config.handler.process_ssm_job")
+    def test_sns_event_processed(self, mock_process):
+        mock_process.return_value = {"status": "ok", "run_id": "r1"}
+
+        payload = {"job_parameters_b64": _make_ssm_job_b64()}
+        event = {"Records": [{"Sns": {"Message": json.dumps(payload)}}]}
+        resp = handler(event)
+        assert resp["status"] == "ok"
+        assert "statusCode" not in resp

--- a/tests/unit/test_ssm_config_models.py
+++ b/tests/unit/test_ssm_config_models.py
@@ -1,0 +1,237 @@
+"""Unit tests for src/ssm_config/models.py."""
+
+import json
+import base64
+
+from src.ssm_config.models import SsmOrder, SsmJob
+
+
+class TestSsmOrder:
+    def test_create_minimal(self):
+        order = SsmOrder(
+            cmds=["echo hello"],
+            timeout=300,
+            ssm_targets={"instance_ids": ["i-abc123"]},
+        )
+        assert order.cmds == ["echo hello"]
+        assert order.timeout == 300
+        assert order.ssm_targets == {"instance_ids": ["i-abc123"]}
+        assert order.must_succeed is True
+        assert order.dependencies is None
+        assert order.order_name is None
+        assert order.env_vars is None
+
+    def test_create_full(self):
+        order = SsmOrder(
+            cmds=["cmd1", "cmd2"],
+            timeout=600,
+            ssm_targets={"tags": [{"Key": "env", "Values": ["prod"]}]},
+            order_name="deploy-ssm",
+            git_repo="org/repo",
+            git_folder="scripts/",
+            commit_hash="abc123",
+            s3_location="s3://bucket/code.zip",
+            env_vars={"KEY": "VALUE"},
+            ssm_paths=["/path/1"],
+            secret_manager_paths=["secret/1"],
+            ssm_document_name="AWS-RunShellScript",
+            queue_id="ssm-queue",
+            dependencies=["dep-1"],
+            must_succeed=False,
+            callback_url="https://callback.example.com",
+        )
+        assert order.order_name == "deploy-ssm"
+        assert order.must_succeed is False
+        assert order.ssm_document_name == "AWS-RunShellScript"
+        assert order.dependencies == ["dep-1"]
+        assert order.callback_url == "https://callback.example.com"
+
+    def test_to_dict(self):
+        order = SsmOrder(
+            cmds=["echo hi"],
+            timeout=300,
+            ssm_targets={"instance_ids": ["i-abc"]},
+        )
+        d = order.to_dict()
+        assert "cmds" in d
+        assert "timeout" in d
+        assert "ssm_targets" in d
+        # None fields should be excluded
+        assert "order_name" not in d
+        assert "env_vars" not in d
+        assert "git_repo" not in d
+
+    def test_to_dict_includes_set_fields(self):
+        order = SsmOrder(
+            cmds=["echo"],
+            timeout=300,
+            ssm_targets={"instance_ids": ["i-1"]},
+            order_name="my-order",
+            env_vars={"A": "B"},
+        )
+        d = order.to_dict()
+        assert d["order_name"] == "my-order"
+        assert d["env_vars"] == {"A": "B"}
+
+    def test_from_dict(self):
+        data = {
+            "cmds": ["echo test"],
+            "timeout": 120,
+            "ssm_targets": {"tags": [{"Key": "Name", "Values": ["web"]}]},
+            "order_name": "test-order",
+            "unknown_field": "ignored",
+        }
+        order = SsmOrder.from_dict(data)
+        assert order.cmds == ["echo test"]
+        assert order.timeout == 120
+        assert order.order_name == "test-order"
+        assert order.ssm_targets == {"tags": [{"Key": "Name", "Values": ["web"]}]}
+
+    def test_from_dict_ignores_unknown_fields(self):
+        data = {
+            "cmds": ["echo"],
+            "timeout": 60,
+            "ssm_targets": {"instance_ids": ["i-1"]},
+            "totally_unknown": "value",
+            "another_extra": 42,
+        }
+        order = SsmOrder.from_dict(data)
+        assert order.cmds == ["echo"]
+        assert not hasattr(order, "totally_unknown")
+
+    def test_ssm_targets_with_instance_ids(self):
+        order = SsmOrder(
+            cmds=["echo"],
+            timeout=300,
+            ssm_targets={"instance_ids": ["i-abc123", "i-def456"]},
+        )
+        assert order.ssm_targets["instance_ids"] == ["i-abc123", "i-def456"]
+
+    def test_ssm_targets_with_tags(self):
+        targets = {"tags": [{"Key": "env", "Values": ["staging", "prod"]}]}
+        order = SsmOrder(cmds=["echo"], timeout=300, ssm_targets=targets)
+        assert order.ssm_targets["tags"][0]["Key"] == "env"
+
+    def test_to_dict_from_dict_roundtrip(self):
+        order = SsmOrder(
+            cmds=["cmd1", "cmd2"],
+            timeout=300,
+            ssm_targets={"instance_ids": ["i-abc"]},
+            order_name="test",
+            env_vars={"A": "B"},
+        )
+        d = order.to_dict()
+        restored = SsmOrder.from_dict(d)
+        assert restored.cmds == order.cmds
+        assert restored.timeout == order.timeout
+        assert restored.order_name == order.order_name
+        assert restored.env_vars == order.env_vars
+        assert restored.ssm_targets == order.ssm_targets
+
+
+class TestSsmJob:
+    def _sample_job(self):
+        return SsmJob(
+            username="testuser",
+            orders=[
+                SsmOrder(
+                    cmds=["echo 1"],
+                    timeout=300,
+                    ssm_targets={"instance_ids": ["i-abc"]},
+                    order_name="order-1",
+                ),
+                SsmOrder(
+                    cmds=["echo 2"],
+                    timeout=600,
+                    ssm_targets={"tags": [{"Key": "env", "Values": ["prod"]}]},
+                    order_name="order-2",
+                ),
+            ],
+            git_repo="org/repo",
+            flow_label="ssm-deploy",
+        )
+
+    def test_create(self):
+        job = self._sample_job()
+        assert job.username == "testuser"
+        assert len(job.orders) == 2
+        assert job.git_repo == "org/repo"
+        assert job.flow_label == "ssm-deploy"
+        assert job.presign_expiry == 7200
+        assert job.job_timeout == 3600
+
+    def test_to_dict(self):
+        job = self._sample_job()
+        d = job.to_dict()
+        assert d["username"] == "testuser"
+        assert len(d["orders"]) == 2
+        assert "cmds" in d["orders"][0]
+        assert "ssm_targets" in d["orders"][0]
+
+    def test_to_dict_excludes_none(self):
+        job = SsmJob(
+            username="user",
+            orders=[],
+        )
+        d = job.to_dict()
+        assert "git_token_location" not in d
+        assert "git_ssh_key_location" not in d
+        assert "commit_hash" not in d
+
+    def test_from_dict(self):
+        data = {
+            "username": "user1",
+            "orders": [
+                {
+                    "cmds": ["cmd1"],
+                    "timeout": 300,
+                    "ssm_targets": {"instance_ids": ["i-1"]},
+                },
+            ],
+            "git_repo": "org/repo",
+        }
+        job = SsmJob.from_dict(data)
+        assert job.username == "user1"
+        assert job.git_repo == "org/repo"
+        assert len(job.orders) == 1
+        assert job.orders[0].cmds == ["cmd1"]
+        assert job.orders[0].ssm_targets == {"instance_ids": ["i-1"]}
+
+    def test_from_dict_ignores_unknown_fields(self):
+        data = {
+            "username": "user1",
+            "orders": [],
+            "unknown_top_level": "ignored",
+        }
+        job = SsmJob.from_dict(data)
+        assert job.username == "user1"
+
+    def test_to_b64_from_b64_roundtrip(self):
+        job = self._sample_job()
+        b64_str = job.to_b64()
+        # Verify it's valid base64
+        decoded = json.loads(base64.b64decode(b64_str).decode())
+        assert decoded["username"] == "testuser"
+        # Verify roundtrip
+        restored = SsmJob.from_b64(b64_str)
+        assert restored.username == job.username
+        assert restored.git_repo == job.git_repo
+        assert len(restored.orders) == len(job.orders)
+        assert restored.orders[0].order_name == job.orders[0].order_name
+        assert restored.orders[0].ssm_targets == job.orders[0].ssm_targets
+        assert restored.orders[1].ssm_targets == job.orders[1].ssm_targets
+
+    def test_default_flow_label(self):
+        job = SsmJob(
+            username="user",
+            orders=[],
+        )
+        assert job.flow_label == "ssm"
+
+    def test_default_presign_expiry(self):
+        job = SsmJob(username="user", orders=[])
+        assert job.presign_expiry == 7200
+
+    def test_default_job_timeout(self):
+        job = SsmJob(username="user", orders=[])
+        assert job.job_timeout == 3600

--- a/tests/unit/test_ssm_config_validate.py
+++ b/tests/unit/test_ssm_config_validate.py
@@ -1,0 +1,123 @@
+"""Unit tests for src/ssm_config/validate.py."""
+
+import pytest
+
+from src.ssm_config.models import SsmJob, SsmOrder
+from src.ssm_config.validate import validate_ssm_orders
+
+
+def _make_job(orders=None, **kwargs):
+    defaults = {
+        "username": "testuser",
+    }
+    defaults.update(kwargs)
+    return SsmJob(orders=orders or [], **defaults)
+
+
+def _make_order(**kwargs):
+    defaults = {
+        "cmds": ["echo hello"],
+        "timeout": 300,
+        "ssm_targets": {"instance_ids": ["i-abc123"]},
+    }
+    defaults.update(kwargs)
+    return SsmOrder(**defaults)
+
+
+class TestValidateSsmOrders:
+    def test_valid_with_instance_ids_passes(self):
+        job = _make_job(orders=[
+            _make_order(ssm_targets={"instance_ids": ["i-abc123"]}),
+        ])
+        errors = validate_ssm_orders(job)
+        assert errors == []
+
+    def test_valid_with_tags_passes(self):
+        job = _make_job(orders=[
+            _make_order(ssm_targets={"tags": [{"Key": "env", "Values": ["prod"]}]}),
+        ])
+        errors = validate_ssm_orders(job)
+        assert errors == []
+
+    def test_no_orders_fails(self):
+        job = _make_job(orders=[])
+        errors = validate_ssm_orders(job)
+        assert len(errors) == 1
+        assert "no orders" in errors[0].lower()
+
+    def test_missing_cmds_fails(self):
+        job = _make_job(orders=[_make_order(cmds=[])])
+        errors = validate_ssm_orders(job)
+        assert len(errors) == 1
+        assert "cmds" in errors[0].lower()
+
+    def test_missing_timeout_fails(self):
+        job = _make_job(orders=[_make_order(timeout=0)])
+        errors = validate_ssm_orders(job)
+        assert len(errors) == 1
+        assert "timeout" in errors[0].lower()
+
+    def test_negative_timeout_fails(self):
+        job = _make_job(orders=[_make_order(timeout=-1)])
+        errors = validate_ssm_orders(job)
+        assert len(errors) == 1
+        assert "timeout" in errors[0].lower()
+
+    def test_missing_ssm_targets_fails(self):
+        job = _make_job(orders=[_make_order(ssm_targets={})])
+        errors = validate_ssm_orders(job)
+        assert len(errors) == 1
+        assert "ssm_targets" in errors[0].lower()
+
+    def test_empty_ssm_targets_no_ids_or_tags_fails(self):
+        job = _make_job(orders=[
+            _make_order(ssm_targets={"other_key": "value"}),
+        ])
+        errors = validate_ssm_orders(job)
+        assert len(errors) == 1
+        assert "instance_ids" in errors[0] or "tags" in errors[0]
+
+    def test_ssm_targets_empty_instance_ids_fails(self):
+        job = _make_job(orders=[
+            _make_order(ssm_targets={"instance_ids": []}),
+        ])
+        errors = validate_ssm_orders(job)
+        assert len(errors) == 1
+        assert "instance_ids" in errors[0] or "tags" in errors[0]
+
+    def test_no_code_source_is_ok(self):
+        """SSM orders don't require git_repo or s3_location."""
+        job = _make_job(
+            git_repo=None,
+            orders=[_make_order()],
+        )
+        errors = validate_ssm_orders(job)
+        assert errors == []
+
+    def test_fail_fast_returns_first_error(self):
+        job = _make_job(orders=[
+            _make_order(cmds=[]),       # invalid: missing cmds
+            _make_order(timeout=0),     # also invalid: bad timeout
+        ])
+        errors = validate_ssm_orders(job)
+        # Only returns first error (fail-fast)
+        assert len(errors) == 1
+        assert "cmds" in errors[0].lower()
+
+    def test_order_name_in_error_message(self):
+        job = _make_job(orders=[
+            _make_order(order_name="deploy-ssm", cmds=[]),
+        ])
+        errors = validate_ssm_orders(job)
+        assert "deploy-ssm" in errors[0]
+
+    def test_multiple_valid_orders_pass(self):
+        job = _make_job(orders=[
+            _make_order(order_name="order-1"),
+            _make_order(
+                order_name="order-2",
+                ssm_targets={"tags": [{"Key": "Name", "Values": ["web"]}]},
+            ),
+        ])
+        errors = validate_ssm_orders(job)
+        assert errors == []

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -82,3 +82,25 @@ class TestValidateOrders:
         job = _make_job(orders=[_make_order(order_name="deploy-vpc", cmds=[])])
         errors = validate_orders(job)
         assert "deploy-vpc" in errors[0]
+
+    def test_invalid_execution_target_fails(self):
+        job = _make_job(orders=[_make_order(execution_target="kubernetes")])
+        errors = validate_orders(job)
+        assert len(errors) == 1
+        assert "execution_target" in errors[0].lower()
+        assert "kubernetes" in errors[0]
+
+    def test_valid_execution_target_lambda(self):
+        job = _make_job(orders=[_make_order(execution_target="lambda")])
+        errors = validate_orders(job)
+        assert errors == []
+
+    def test_valid_execution_target_codebuild(self):
+        job = _make_job(orders=[_make_order(execution_target="codebuild")])
+        errors = validate_orders(job)
+        assert errors == []
+
+    def test_valid_execution_target_ssm(self):
+        job = _make_job(orders=[_make_order(execution_target="ssm")])
+        errors = validate_orders(job)
+        assert errors == []


### PR DESCRIPTION
Add a third execution target (SSM) alongside Lambda and CodeBuild for executing commands on existing EC2 instances via AWS Systems Manager. This enables tool-agnostic server configuration (Ansible, shell scripts, Chef recipes, etc.) through a separate entry point that shares the existing orchestrator for dependency resolution and tracking.

Key changes:
- New src/ssm_config/ module with separate Lambda entry point (POST /ssm)
- Replace use_lambda bool with execution_target string (lambda/codebuild/ssm)
- Extract shared code source functions into src/common/code_source.py
- Add SSM dispatch to orchestrator with custom SSM Document
- Custom iac-ci-run-commands SSM Document for command execution on EC2
- Full Terraform infrastructure (IAM, Lambda, API Gateway route, SSM Document)
- Backward compatibility for legacy use_lambda field in from_dict()

https://claude.ai/code/session_01FS7u2HajB9cLxkm5Jtkm6z