### PR TITLE
Remove all webhook references; system uses SigV4 + JWT contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 iac-ci is a generic, event-driven continuous delivery system for infrastructure-as-code and arbitrary command execution. It is AWS-native (Lambda, DynamoDB, S3, CodeBuild, SSM, Step Functions, API Gateway, ECR) and uses a single Docker image with multiple entrypoints for all Lambda functions and CodeBuild workers.
 
-The system processes jobs containing multiple orders, queues them in DynamoDB, and executes them via Lambda, CodeBuild, or SSM Run Command with full dependency resolution, cross-account credential management via SOPS, and PR comment tracking via VCS webhooks.
+The system processes jobs containing multiple orders, queues them in DynamoDB, and executes them via Lambda, CodeBuild, or SSM Run Command with full dependency resolution, cross-account credential management via SOPS, and PR comment tracking via VCS.
 
 ## Architecture
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,7 @@ The system is split into three flows:
 
 ---
 
-## Part 1: init_job (ProcessWebhook Lambda)
+## Part 1: init_job Lambda
 
 ### Upstream
 
@@ -31,8 +31,8 @@ flowchart TB
 
     Note["cmds[] already resolved"]
 
-    APIGW["API Gateway<br><i>GitHub webhook signature verification</i>"]
-    IJ["init_job Lambda<br><i>POST /webhook</i>"]
+    APIGW["API Gateway<br><i>SigV4 + JWT authentication</i>"]
+    IJ["init_job Lambda<br><i>POST /init</i>"]
     SSMCfg["ssm_config Lambda<br><i>POST /ssm</i>"]
 
     SNS --> Note

--- a/docs/ARCHITECTURE_DIAGRAM.md
+++ b/docs/ARCHITECTURE_DIAGRAM.md
@@ -8,11 +8,11 @@ Visual overview of the iac-ci system. For an interactive version with full detai
 
 ```mermaid
 flowchart LR
-    VCS["VCS / Webhook<br><i>PR event or API call</i>"]
+    VCS["Caller<br><i>SigV4 + JWT</i>"]
     AWS["Your AWS Account<br><i>Validates, queues, executes</i>"]
     Results["Results<br><i>PR comment + logs</i>"]
 
-    VCS -- "POST /webhook<br>job payload" --> AWS
+    VCS -- "POST /init<br>job payload" --> AWS
     AWS -- "PR comment<br>+ status update" --> Results
 
     style VCS fill:#1e3a5f,stroke:#3b82f6,color:#e2e8f0
@@ -29,11 +29,11 @@ flowchart LR
 
 ## Part 1: init_job
 
-Webhook intake -- validates, packages, and queues orders.
+Job intake -- validates, packages, and queues orders.
 
 ```mermaid
 sequenceDiagram
-    participant VCS as VCS / Webhook
+    participant VCS as Caller
     participant APIGW as API Gateway
     participant IJ as init_job Lambda
     participant SSM as SSM Parameter Store
@@ -41,7 +41,7 @@ sequenceDiagram
     participant DDB as DynamoDB
     participant PR as VCS PR
 
-    VCS->>APIGW: POST /webhook (job payload)
+    VCS->>APIGW: POST /init (job payload)
     APIGW->>IJ: Invoke (AWS_PROXY)
 
     Note over IJ: Validate orders<br>(cmds, timeout, code source)
@@ -115,7 +115,7 @@ sequenceDiagram
 ```mermaid
 graph TB
     subgraph Ingress
-        APIGW["API Gateway<br><i>iac-ci-webhook</i><br>POST /webhook"]
+        APIGW["API Gateway<br><i>iac-ci-api</i><br>POST /init"]
         InitJob["init_job Lambda<br><i>300s · 512MB</i>"]
     end
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -88,7 +88,7 @@ Generates:
       region       = <region>
 
 Creates:
-  - API Gateway (HTTP API, POST /webhook)
+  - API Gateway (HTTP API, POST /init, POST /ssm)
   - 4 Lambda functions (all ECR image, different entrypoints)
   - Step Function (watchdog state machine)
   - 3 DynamoDB tables (orders, order_events + GSI, locks)
@@ -102,7 +102,7 @@ Creates:
 
 ```
 Test 1: API Gateway health
-  curl POST <api_gw_url>/webhook
+  curl POST <api_gw_url>/init
   expect: 400 (no payload)
 
 Test 2: Lambda invoke

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -21,7 +21,7 @@ iac-ci/
 │   │   └── vcs/
 │   │       ├── __init__.py
 │   │       ├── base.py                # ABC interface for VCS providers
-│   │       └── github.py              # GitHub: PR comments, webhook verify
+│   │       └── github.py              # GitHub: PR comments
 │   │
 │   ├── init_job/                      # Part 1: init_job
 │   │   ├── __init__.py
@@ -78,7 +78,7 @@ iac-ci/
 │       ├── main.tf
 │       ├── variables.tf
 │       ├── outputs.tf
-│       ├── api_gateway.tf             # HTTP API + POST /webhook + POST /ssm
+│       ├── api_gateway.tf             # HTTP API + POST /init + POST /ssm
 │       ├── lambdas.tf                 # 5 Lambda functions (all ECR image)
 │       ├── step_functions.tf          # watchdog state machine
 │       ├── dynamodb.tf                # orders, order_events (+GSI), locks
@@ -185,7 +185,7 @@ flowchart TB
 | `sops.py` | Encrypt env_vars + creds into SOPS bundle, decrypt, auto-gen temp keys |
 | `code_source.py` | Shared code source operations: git clone, S3 fetch, credential retrieval (SSM/Secrets Manager), zip (extracted from init_job/repackage.py) |
 | `vcs/base.py` | ABC: create_comment, update_comment, find_comment_by_tag |
-| `vcs/github.py` | GitHub implementation + webhook signature verification |
+| `vcs/github.py` | GitHub implementation: PR comments, CRUD, pagination |
 
 ### src/init_job/
 

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -1,6 +1,6 @@
 # Variables Reference
 
-Complete reference for `job_parameters_b64` — the base64-encoded payload sent to the `init_job` Lambda (via `POST /webhook`) or the `ssm_config` Lambda (via `POST /ssm`).
+Complete reference for `job_parameters_b64` — the base64-encoded payload sent to the `init_job` Lambda (via `POST /init`) or the `ssm_config` Lambda (via `POST /ssm`).
 
 ---
 
@@ -87,7 +87,7 @@ Complete reference for `job_parameters_b64` — the base64-encoded payload sent 
 }
 ```
 
-This payload is base64-encoded before being sent to the `init_job` Lambda via `POST /webhook`.
+This payload is base64-encoded before being sent to the `init_job` Lambda via `POST /init`.
 
 ---
 

--- a/docs/architecture-diagram.html
+++ b/docs/architecture-diagram.html
@@ -540,19 +540,19 @@
   <!-- ═══════════════════════════════════════ -->
   <div class="overview">
     <div class="overview-title">How It Works</div>
-    <div class="overview-subtitle">Jobs come in via webhook, execute on your AWS account, results go back to your PR</div>
+    <div class="overview-subtitle">Jobs come in via API, execute on your AWS account, results go back to your PR</div>
 
     <div class="simple-flow">
-      <!-- VCS / Webhook -->
+      <!-- Caller -->
       <div class="sf-node">
         <div class="sf-box blue">
-          <div class="sf-box-label">VCS / Webhook</div>
+          <div class="sf-box-label">Caller</div>
           <div class="sf-box-desc">
             Sends job payload<br>
-            (PR event, API call)
+            (SigV4 + JWT)
           </div>
         </div>
-        <span class="sf-who external">External trigger</span>
+        <span class="sf-who external">External caller</span>
       </div>
 
       <!-- Arrow 1 -->
@@ -562,7 +562,7 @@
           <span class="head">&#9656;</span>
         </div>
         <div class="sf-arrow-text">
-          POST /webhook<br>
+          POST /init<br>
           job payload
         </div>
       </div>
@@ -644,8 +644,8 @@
             <span class="component-icon icon-apigw">APIGW</span>
             <div class="component-name">API Gateway</div>
             <div class="component-detail">
-              iac-ci-webhook<br>
-              POST /webhook<br>
+              iac-ci-api<br>
+              POST /init, POST /ssm<br>
               HTTP API, auto-deploy
             </div>
           </div>
@@ -838,8 +838,8 @@
       <div class="flow-step flow-blue">
         <div class="step-line"><div class="step-dot"></div><div class="step-connector"></div></div>
         <div class="step-content">
-          <div class="step-label">1 &rsaquo; VCS webhook &rarr; API Gateway</div>
-          <div class="step-desc">POST /webhook with job payload containing orders, dependencies, and target account info</div>
+          <div class="step-label">1 &rsaquo; Caller &rarr; API Gateway</div>
+          <div class="step-desc">POST /init with job payload containing orders, dependencies, and target account info</div>
           <span class="step-tag tag-event">APIGW</span>
         </div>
       </div>

--- a/docs/prompts/PHASE_1_COMMON.md
+++ b/docs/prompts/PHASE_1_COMMON.md
@@ -122,7 +122,6 @@ Create src/common/vcs/__init__.py (empty).
 Create src/common/vcs/base.py:
 
 ABC class VcsProvider with abstract methods:
-- verify_webhook(headers, body, secret): return bool
 - create_comment(repo, pr_number, body, token): return comment_id
 - update_comment(repo, comment_id, body, token): return bool
 - find_comment_by_tag(repo, pr_number, tag, token): return comment_id or None
@@ -131,7 +130,6 @@ ABC class VcsProvider with abstract methods:
 Create src/common/vcs/github.py:
 
 GitHubProvider(VcsProvider) implementation:
-- verify_webhook: HMAC-SHA256 verification of X-Hub-Signature-256
 - create_comment: POST to GitHub REST API /repos/{repo}/issues/{pr_number}/comments
 - update_comment: PATCH to /repos/{repo}/issues/comments/{comment_id}
 - find_comment_by_tag: GET all comments, search for tag string in body
@@ -156,7 +154,7 @@ Create unit tests in tests/unit/ for all common modules:
 - test_dynamodb.py: use moto to mock DynamoDB. Test all CRUD operations, conditional lock acquire/release, TTL fields
 - test_s3.py: use moto to mock S3. Test upload, presigned URL generation, read/write result.json, init trigger, done endpoint
 - test_sops.py: mock subprocess calls to sops/age-keygen. Test encrypt/decrypt round-trip, repackage_order file layout
-- test_vcs_github.py: use responses library to mock GitHub API. Test webhook verification, CRUD on comments, find_comment_by_tag with pagination
+- test_vcs_github.py: use responses library to mock GitHub API. Test CRUD on comments, find_comment_by_tag with pagination
 
 Use pytest. Each test file should be independent. Use fixtures for common setup.
 ```

--- a/docs/prompts/PHASE_4_TERRAFORM.md
+++ b/docs/prompts/PHASE_4_TERRAFORM.md
@@ -75,7 +75,7 @@ main.tf:
 
 api_gateway.tf:
 - HTTP API (aws_apigatewayv2_api)
-- POST /webhook route → init_job Lambda integration
+- POST /init route → init_job Lambda integration
 - Stage: $default with auto_deploy
 
 lambdas.tf:

--- a/docs/prompts/PHASE_5_CICD.md
+++ b/docs/prompts/PHASE_5_CICD.md
@@ -216,7 +216,7 @@ Expects environment variables:
 - DONE_BUCKET
 
 Tests (each prints PASS/FAIL):
-1. API Gateway responds: curl -s -o /dev/null -w "%{http_code}" -X POST ${API_GATEWAY_URL}/webhook → expect 4xx (no payload is fine, just not 5xx or connection refused)
+1. API Gateway responds: curl -s -o /dev/null -w "%{http_code}" -X POST ${API_GATEWAY_URL}/init → expect 4xx (no payload is fine, just not 5xx or connection refused)
 2. init_job Lambda exists: aws lambda get-function --function-name iac-ci-init-job
 3. orchestrator Lambda exists: aws lambda get-function --function-name iac-ci-orchestrator
 4. watchdog_check Lambda exists: aws lambda get-function --function-name iac-ci-watchdog-check

--- a/infra/02-deploy/api_gateway.tf
+++ b/infra/02-deploy/api_gateway.tf
@@ -1,24 +1,24 @@
-resource "aws_apigatewayv2_api" "webhook" {
-  name          = "iac-ci-webhook"
+resource "aws_apigatewayv2_api" "api" {
+  name          = "iac-ci-api"
   protocol_type = "HTTP"
 }
 
 resource "aws_apigatewayv2_stage" "default" {
-  api_id      = aws_apigatewayv2_api.webhook.id
+  api_id      = aws_apigatewayv2_api.api.id
   name        = "$default"
   auto_deploy = true
 }
 
 resource "aws_apigatewayv2_integration" "init_job" {
-  api_id                 = aws_apigatewayv2_api.webhook.id
+  api_id                 = aws_apigatewayv2_api.api.id
   integration_type       = "AWS_PROXY"
   integration_uri        = aws_lambda_function.init_job.invoke_arn
   payload_format_version = "2.0"
 }
 
-resource "aws_apigatewayv2_route" "post_webhook" {
-  api_id    = aws_apigatewayv2_api.webhook.id
-  route_key = "POST /webhook"
+resource "aws_apigatewayv2_route" "post_init" {
+  api_id    = aws_apigatewayv2_api.api.id
+  route_key = "POST /init"
   target    = "integrations/${aws_apigatewayv2_integration.init_job.id}"
 }
 
@@ -27,20 +27,20 @@ resource "aws_lambda_permission" "apigw_invoke" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.init_job.function_name
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "${aws_apigatewayv2_api.webhook.execution_arn}/*/*"
+  source_arn    = "${aws_apigatewayv2_api.api.execution_arn}/*/*"
 }
 
 # --- SSM config route ---
 
 resource "aws_apigatewayv2_integration" "ssm_config" {
-  api_id                 = aws_apigatewayv2_api.webhook.id
+  api_id                 = aws_apigatewayv2_api.api.id
   integration_type       = "AWS_PROXY"
   integration_uri        = aws_lambda_function.ssm_config.invoke_arn
   payload_format_version = "2.0"
 }
 
 resource "aws_apigatewayv2_route" "post_ssm" {
-  api_id    = aws_apigatewayv2_api.webhook.id
+  api_id    = aws_apigatewayv2_api.api.id
   route_key = "POST /ssm"
   target    = "integrations/${aws_apigatewayv2_integration.ssm_config.id}"
 }
@@ -50,5 +50,5 @@ resource "aws_lambda_permission" "apigw_ssm_config" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.ssm_config.function_name
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "${aws_apigatewayv2_api.webhook.execution_arn}/*/*"
+  source_arn    = "${aws_apigatewayv2_api.api.execution_arn}/*/*"
 }

--- a/infra/02-deploy/outputs.tf
+++ b/infra/02-deploy/outputs.tf
@@ -1,11 +1,11 @@
 output "api_gateway_url" {
   description = "API Gateway endpoint URL"
-  value       = aws_apigatewayv2_api.webhook.api_endpoint
+  value       = aws_apigatewayv2_api.api.api_endpoint
 }
 
 output "api_gateway_id" {
   description = "API Gateway ID"
-  value       = aws_apigatewayv2_api.webhook.id
+  value       = aws_apigatewayv2_api.api.id
 }
 
 output "lambda_function_names" {

--- a/src/common/vcs/base.py
+++ b/src/common/vcs/base.py
@@ -12,11 +12,6 @@ class VcsProvider(ABC):
     """
 
     @abstractmethod
-    def verify_webhook(self, headers: dict, body: bytes, secret: str) -> bool:
-        """Verify webhook signature. Returns True if valid."""
-        ...
-
-    @abstractmethod
     def create_comment(self, repo: str, pr_number: int, body: str, token: str) -> int:
         """Create a comment on a PR. Returns comment_id."""
         ...

--- a/src/common/vcs/github.py
+++ b/src/common/vcs/github.py
@@ -1,7 +1,5 @@
 """GitHub VCS provider implementation."""
 
-import hashlib
-import hmac
 from typing import List, Optional
 
 import requests
@@ -22,16 +20,6 @@ class GitHubProvider(VcsProvider):
             "Authorization": f"Bearer {token}",
             "Accept": "application/vnd.github+json",
         }
-
-    def verify_webhook(self, headers: dict, body: bytes, secret: str) -> bool:
-        """Verify GitHub webhook HMAC-SHA256 signature."""
-        signature = headers.get("X-Hub-Signature-256", "")
-        if not signature.startswith("sha256="):
-            return False
-        expected = hmac.new(
-            secret.encode(), body, hashlib.sha256
-        ).hexdigest()
-        return hmac.compare_digest(signature[7:], expected)
 
     def get_comments(
         self, repo: str, pr_number: int, token: str,

--- a/src/common/vcs/helper.py
+++ b/src/common/vcs/helper.py
@@ -22,7 +22,7 @@ class VcsHelper:
 
     Responsibilities:
     - Factory: instantiate the right provider via provider="github" etc.
-    - Delegates raw VCS operations (create/update/delete/verify) to the provider.
+    - Delegates raw VCS operations (create/update/delete) to the provider.
     - Adds shared business logic that works across all providers:
       search_comments, upsert_comment, format_tags, has_tag_block_at_last_line.
 
@@ -47,9 +47,6 @@ class VcsHelper:
     # ------------------------------------------------------------------
     # Delegated provider operations
     # ------------------------------------------------------------------
-
-    def verify_webhook(self, headers: dict, body: bytes, secret: str) -> bool:
-        return self._provider.verify_webhook(headers, body, secret)
 
     def create_comment(self, repo: str, pr_number: int, body: str, token: str) -> int:
         return self._provider.create_comment(repo, pr_number, body, token)

--- a/tests/smoke/test_deploy.sh
+++ b/tests/smoke/test_deploy.sh
@@ -16,7 +16,7 @@ for var in API_GATEWAY_URL AWS_REGION ORDERS_TABLE ORDER_EVENTS_TABLE LOCKS_TABL
 done
 
 # 1. API Gateway responds (expect 4xx, not 5xx or connection error)
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${API_GATEWAY_URL}/webhook" 2>/dev/null || echo "000")
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${API_GATEWAY_URL}/init" 2>/dev/null || echo "000")
 if [[ "$HTTP_CODE" =~ ^4[0-9]{2}$ ]]; then
   pass "API Gateway responds (HTTP $HTTP_CODE)"
 else
@@ -24,7 +24,7 @@ else
 fi
 
 # 2-5. Lambda functions exist
-for FUNC in iac-ci-process-webhook iac-ci-orchestrator iac-ci-watchdog-check iac-ci-worker; do
+for FUNC in iac-ci-init-job iac-ci-orchestrator iac-ci-watchdog-check iac-ci-worker; do
   if aws lambda get-function --function-name "$FUNC" --region "$AWS_REGION" >/dev/null 2>&1; then
     pass "Lambda $FUNC exists"
   else

--- a/tests/unit/test_vcs_github.py
+++ b/tests/unit/test_vcs_github.py
@@ -1,7 +1,5 @@
 """Unit tests for src/common/vcs/github.py — GitHub provider layer."""
 
-import hashlib
-import hmac
 import json
 
 import pytest
@@ -13,31 +11,6 @@ from src.common.vcs.github import GitHubProvider, GITHUB_API_BASE
 @pytest.fixture
 def github():
     return GitHubProvider()
-
-
-# ---------------------------------------------------------------------------
-# Webhook verification
-# ---------------------------------------------------------------------------
-
-
-class TestVerifyWebhook:
-    def test_valid_signature(self, github):
-        secret = "mysecret"
-        body = b'{"action":"opened"}'
-        sig = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
-        headers = {"X-Hub-Signature-256": f"sha256={sig}"}
-        assert github.verify_webhook(headers, body, secret) is True
-
-    def test_invalid_signature(self, github):
-        headers = {"X-Hub-Signature-256": "sha256=invalid"}
-        assert github.verify_webhook(headers, b"body", "secret") is False
-
-    def test_missing_signature(self, github):
-        assert github.verify_webhook({}, b"body", "secret") is False
-
-    def test_wrong_prefix(self, github):
-        headers = {"X-Hub-Signature-256": "md5=abc"}
-        assert github.verify_webhook(headers, b"body", "secret") is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The execution engine is invoked by a calling system via API contract, not through webhooks. This change removes all webhook-related code, renames the API Gateway route from POST /webhook to POST /init, and updates all documentation to reflect the contract-based invocation model.

- Remove verify_webhook() from VCS base, GitHub provider, and helper
- Remove HMAC-SHA256 signature verification code and imports
- Remove TestVerifyWebhook test class
- Rename API Gateway: iac-ci-webhook -> iac-ci-api
- Rename route: POST /webhook -> POST /init
- Fix smoke test Lambda name: iac-ci-process-webhook -> iac-ci-init-job
- Update all docs, diagrams, and prompt references

https://claude.ai/code/session_01GSSvdr3HWtYTdPHoEWmrv9