### PR TITLE
feat(aws_exe_sys): finalize asynchronous CodeBuild executions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,11 @@
 
 `aws_exe_sys` is a generic AWS-native execution helper.
 
-It exposes two Lambda entry points:
+It exposes three Lambda entry points:
 
 - `init_job` — validate payload and dispatch work.
-- `worker` — execute commands and write the terminal result to S3.
+- `worker` — execute commands and write the detailed terminal result to S3.
+- `finalizer` — atomically create a missing failed CodeBuild fallback result.
 
 ## Contract
 
@@ -34,9 +35,10 @@ SimplePayload:
 `init_job` selects target behavior by `execution_target`:
 
 - `lambda` → async `Invoke` of `AWS_EXE_SYS_WORKER_LAMBDA`
-- `codebuild` → `start_build` on `AWS_EXE_SYS_CODEBUILD_PROJECT`
+- `codebuild` → async `StartExecution` of `AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN`
 
-All seven payload fields are passed as plain strings.
+The Standard workflow starts the managed CodeBuild worker with all seven payload fields as plain-string
+environment overrides, waits for a terminal build state, and invokes the finalizer.
 
 ### 3. Worker run and completion
 
@@ -47,4 +49,6 @@ All seven payload fields are passed as plain strings.
 3. runs `commands_b64` sequentially
 4. writes an `ExecutionResult` JSON object to `done_endpoint`; a write failure propagates
 
-Completion is detected by the presence of the `done_endpoint` object (no callbacks or polling API).
+For CodeBuild, the worker is the primary result writer. The finalizer uses `If-None-Match: *` to preserve an
+existing marker or create a canonical failed fallback when the marker is missing. Non-precondition S3 errors
+propagate. Completion is detected by the presence of the `done_endpoint` object (no callbacks or polling API).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,54 +1,15 @@
-# AWS execution engine contract
+# AWS execution engine guidance
 
-`aws_exe_sys` is a generic AWS-native execution helper.
+`CONTRACT.md` owns the caller payload, dispatch, and result contract.
 
-It exposes three Lambda entry points:
+Keep these high-value invariants in mind when changing the engine:
 
-- `init_job` — validate payload and dispatch work.
-- `worker` — execute commands and write the detailed terminal result to S3.
-- `finalizer` — atomically create a missing failed CodeBuild fallback result.
-
-## Contract
-
-### 1. Submission (caller → `init_job`)
-
-Callers submit a JSON payload with the seven fields below.
-
-```text
-SimplePayload:
-  trigger_id      (required)
-  s3_package_uri  (required, s3://...) - zip with executable files
-  sops_type       (optional: null | "ssm" | "kms")
-  sops_path       (required when sops_type == "ssm")
-  commands_b64    (required base64-encoded JSON array of commands)
-  done_endpoint   (required, s3://...) - marker sink
-  execution_target(required: "lambda" | "codebuild")
-```
-
-`init_job` responds with:
-
-- `{"status": "ok", "trigger_id": "..."}` on successful dispatch.
-- `{"status": "error", ...}` when validation or pre-flight checks fail.
-
-### 2. Dispatch
-
-`init_job` selects target behavior by `execution_target`:
-
-- `lambda` → async `Invoke` of `AWS_EXE_SYS_WORKER_LAMBDA`
-- `codebuild` → async `StartExecution` of `AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN`
-
-The Standard workflow starts the managed CodeBuild worker with all seven payload fields as plain-string
-environment overrides, waits for a terminal build state, and invokes the finalizer.
-
-### 3. Worker run and completion
-
-`worker`:
-
-1. downloads and unpacks `s3_package_uri`
-2. optionally decrypts secrets according to `sops_type`/`sops_path`
-3. runs `commands_b64` sequentially
-4. writes an `ExecutionResult` JSON object to `done_endpoint`; a write failure propagates
-
-For CodeBuild, the worker is the primary result writer. The finalizer uses `If-None-Match: *` to preserve an
-existing marker or create a canonical failed fallback when the marker is missing. Non-precondition S3 errors
-propagate. Completion is detected by the presence of the `done_endpoint` object (no callbacks or polling API).
+- `aws_exe_sys` is a generic AWS-native execution helper with three Lambda entry points: `init_job`, `worker`,
+  and `finalizer`.
+- Preserve the seven-field `SimplePayload` caller contract and the existing Lambda dispatch path.
+- `lambda` dispatch asynchronously invokes `AWS_EXE_SYS_WORKER_LAMBDA`; `codebuild` dispatch asynchronously
+  starts `AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN`.
+- The Standard CodeBuild workflow passes all seven payload fields as plain-string CodeBuild environment
+  overrides, waits for a terminal build state, and invokes the finalizer.
+- `done_endpoint` is the only caller completion marker. The worker is the primary result writer; the finalizer
+  only creates a missing failed fallback with `If-None-Match: *` and propagates non-precondition S3 errors.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,8 @@
 This repository documents a single generic execution interface:
 
 - **`init_job`** validates and dispatches work.
-- **`worker`** runs commands on the selected target and writes a terminal result to S3.
+- **`worker`** runs commands on the selected target and writes a detailed terminal result to S3.
+- **`finalizer`** atomically creates a missing failed fallback after a terminal CodeBuild run.
 
 ## Scope
 
@@ -29,15 +30,16 @@ The engine receives a pre-resolved command payload and has no stack-specific bus
 caller
   -> init_job
     -> validate payload + referenced resources
-      -> dispatch to selected target
-        -> worker (Lambda/CodeBuild)
-          -> execute command list
-            -> write ExecutionResult to done_endpoint
+      -> Lambda worker, or Standard Step Functions workflow for CodeBuild
+        -> worker executes command list and writes ExecutionResult
+        -> CodeBuild workflow invokes finalizer
+          -> preserve worker result or create missing failed fallback
 ```
 
 ## Notes
 
 - `done_endpoint` is the single completion marker and is treated as terminal when present.
+- Step Functions execution history is operational metadata, not the caller completion API.
 - `sops_type == null` runs with no secret decryption.
 - `sops_type == ssm` uses an SSM parameter at `sops_path`.
 - `sops_type == kms` uses SOPS metadata in the package, no explicit `sops_path` required.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,45 +1,5 @@
-# AWS execution engine usage contract
+# AWS execution engine guidance
 
-This repository documents a single generic execution interface:
-
-- **`init_job`** validates and dispatches work.
-- **`worker`** runs commands on the selected target and writes a detailed terminal result to S3.
-- **`finalizer`** atomically creates a missing failed fallback after a terminal CodeBuild run.
-
-## Scope
-
-The engine receives a pre-resolved command payload and has no stack-specific business logic.
-
-## Data contract
-
-`init_job` accepts a `SimplePayload` with seven fields:
-
-1. `trigger_id`
-2. `s3_package_uri`
-3. `sops_type` (`null`, `ssm`, or `kms`)
-4. `sops_path` (required only when `sops_type == "ssm"`)
-5. `commands_b64`
-6. `done_endpoint`
-7. `execution_target` (`lambda` or `codebuild`)
-
-`worker` writes an `ExecutionResult` to `done_endpoint`; marker-write failures propagate.
-
-## Run flow
-
-```text
-caller
-  -> init_job
-    -> validate payload + referenced resources
-      -> Lambda worker, or Standard Step Functions workflow for CodeBuild
-        -> worker executes command list and writes ExecutionResult
-        -> CodeBuild workflow invokes finalizer
-          -> preserve worker result or create missing failed fallback
-```
-
-## Notes
-
-- `done_endpoint` is the single completion marker and is treated as terminal when present.
-- Step Functions execution history is operational metadata, not the caller completion API.
-- `sops_type == null` runs with no secret decryption.
-- `sops_type == ssm` uses an SSM parameter at `sops_path`.
-- `sops_type == kms` uses SOPS metadata in the package, no explicit `sops_path` required.
+`AGENTS.md` owns repo-specific agent guidance. `CONTRACT.md` owns the caller payload, dispatch, and result
+contract; consult it before changing payload fields, execution targets, result persistence, or completion
+semantics.

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -3,7 +3,7 @@
 Version: 3.0
 
 `aws_exe_sys` is a generic command runner. It accepts a prepared command payload,
-executes it on a selected target (`lambda` or `codebuild`), and writes one terminal result to S3.
+executes it on a selected target (`lambda` or `codebuild`), and guarantees one attempted terminal result write to S3.
 
 Version 3.0 removes the unused `ssm` execution target. The payload still contains exactly seven fields.
 
@@ -37,9 +37,12 @@ Acknowledgement on dispatch:
 `init_job` validates the payload and routes to:
 
 - `lambda`: asynchronous invocation of `AWS_EXE_SYS_WORKER_LAMBDA`.
-- `codebuild`: start a build in `AWS_EXE_SYS_CODEBUILD_PROJECT` with all seven fields as environment variables.
+- `codebuild`: asynchronous start of the Standard workflow in `AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN`.
+  The workflow starts the managed CodeBuild project with all seven fields as environment variables,
+  waits for a terminal build state, and invokes the finalizer.
 
-The payload is passed as plain string values to each target.
+The payload is passed as plain string values to each target. Successful `init_job` acknowledgement for
+CodeBuild means Step Functions accepted the execution; it does not mean the build completed.
 
 ## Result
 
@@ -63,3 +66,9 @@ The payload is passed as plain string values to each target.
 ```
 
 Presence of this object is terminal. A result-write failure is raised by the worker rather than being reported as successful execution.
+
+For CodeBuild, the worker remains the primary writer of the detailed result. After CodeBuild reaches a
+terminal state, the finalizer performs an atomic conditional S3 write (`If-None-Match: *`). It preserves an
+existing worker result. If no result exists, it writes a canonical `failed` result with an empty `steps` list
+and a stable `codebuild_*_without_result` error classification. A successful build without a worker marker is
+therefore a failed contract outcome. Other S3 errors propagate and fail the Step Functions execution.

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -3,7 +3,8 @@
 Version: 3.0
 
 `aws_exe_sys` is a generic command runner. It accepts a prepared command payload,
-executes it on a selected target (`lambda` or `codebuild`), and guarantees one attempted terminal result write to S3.
+executes it on a selected target (`lambda` or `codebuild`), and uses one S3 `ExecutionResult` object as the
+terminal marker.
 
 Version 3.0 removes the unused `ssm` execution target. The payload still contains exactly seven fields.
 
@@ -38,15 +39,15 @@ Acknowledgement on dispatch:
 
 - `lambda`: asynchronous invocation of `AWS_EXE_SYS_WORKER_LAMBDA`.
 - `codebuild`: asynchronous start of the Standard workflow in `AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN`.
-  The workflow starts the managed CodeBuild project with all seven fields as environment variables,
-  waits for a terminal build state, and invokes the finalizer.
+  The workflow starts the managed CodeBuild project with all seven fields as plain-string CodeBuild
+  environment overrides, waits for a terminal build state, and invokes the finalizer.
 
 The payload is passed as plain string values to each target. Successful `init_job` acknowledgement for
 CodeBuild means Step Functions accepted the execution; it does not mean the build completed.
 
 ## Result
 
-`worker` writes one `ExecutionResult` object to `done_endpoint`:
+The primary worker writes the detailed `ExecutionResult` object to `done_endpoint`:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 `aws_exe_sys` is a small AWS-native execution adapter.
 
-It provides a two-step flow:
+It provides a caller-facing flow:
 
 1. `init_job` receives a **7-field payload** and dispatches to a target.
-2. `worker` executes the commands and writes an `ExecutionResult` to S3.
+2. The selected runtime writes an `ExecutionResult` to S3.
 
 CodeBuild requests are owned by a Standard Step Functions workflow, which waits for the build and invokes a
 fallback finalizer so a pre-worker CodeBuild failure cannot leave the caller waiting forever.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ It provides a two-step flow:
 1. `init_job` receives a **7-field payload** and dispatches to a target.
 2. `worker` executes the commands and writes an `ExecutionResult` to S3.
 
+CodeBuild requests are owned by a Standard Step Functions workflow, which waits for the build and invokes a
+fallback finalizer so a pre-worker CodeBuild failure cannot leave the caller waiting forever.
+
 Supported execution targets:
 - `lambda`
 - `codebuild`
@@ -45,7 +48,9 @@ Set `additional_package_bucket_arns` and `additional_result_bucket_arns` when us
 - `init_job` validates payload shape and references (`s3://...`, optional SSM key).
 - `worker` downloads and unpacks the zip, applies SOPS if configured, then runs commands sequentially.
 - `worker` writes a terminal `ExecutionResult` to `done_endpoint` on success or execution failure.
-- If the result cannot be persisted, the worker raises instead of falsely reporting success.
+- For CodeBuild, Step Functions waits for the terminal build state and invokes `finalizer`.
+- `finalizer` atomically creates only a missing failed fallback; it never overwrites a worker result.
+- If the result cannot be persisted, the worker/finalizer raises instead of falsely reporting success.
 
 See `CONTRACT.md` for the exact response and result schema.
 
@@ -54,7 +59,7 @@ See `CONTRACT.md` for the exact response and result schema.
 The matching variable is required for each dispatch path:
 
 - `AWS_EXE_SYS_WORKER_LAMBDA` (for `lambda` dispatch)
-- `AWS_EXE_SYS_CODEBUILD_PROJECT` (for `codebuild` dispatch)
+- `AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN` (for `codebuild` dispatch)
 
 The Terraform deployment also sets the managed package and result bucket names:
 

--- a/aws_exe_sys/finalizer/__init__.py
+++ b/aws_exe_sys/finalizer/__init__.py
@@ -1,0 +1,4 @@
+"""CodeBuild terminal-result finalizer service."""
+
+# Service, not a library — invoked as a Lambda handler.
+__all__: list[str] = []

--- a/aws_exe_sys/finalizer/handler.py
+++ b/aws_exe_sys/finalizer/handler.py
@@ -1,0 +1,101 @@
+"""Create a failed fallback result when CodeBuild did not write one."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+from aws_exe_sys.common.result_writer import ExecutionResult, _parse_s3_uri
+
+_SUCCEEDED = "codebuild_succeeded_without_result"
+_FAILED = "codebuild_failed_without_result"
+_TIMED_OUT = "codebuild_timed_out_without_result"
+_STOPPED = "codebuild_stopped_without_result"
+_TERMINAL_RESULT_MISSING = "codebuild_terminal_result_missing"
+
+
+def _require_non_empty_string(event: dict[str, Any], field: str) -> str:
+    if field not in event:
+        raise ValueError(f"{field} is required")
+
+    value = event[field]
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def _require_terminal_context(event: dict[str, Any]) -> dict[str, Any]:
+    if "terminal_context" not in event:
+        raise ValueError("terminal_context is required")
+
+    terminal_context = event["terminal_context"]
+    if not isinstance(terminal_context, dict):
+        raise ValueError("terminal_context must be an object")
+    return terminal_context
+
+
+def _classify_terminal_context(terminal_context: dict[str, Any]) -> str:
+    if "outcome" in terminal_context:
+        outcome = terminal_context["outcome"]
+        if outcome == "succeeded":
+            return _SUCCEEDED
+        elif outcome != "failed":
+            raise ValueError(f"unknown terminal outcome: {outcome!r}")
+    elif "Error" in terminal_context and "Cause" in terminal_context:
+        pass
+    else:
+        return _TERMINAL_RESULT_MISSING
+
+    serialized = json.dumps(terminal_context, sort_keys=True, separators=(",", ":")).upper()
+    if any(token in serialized for token in ("TIMED_OUT", "TIMED OUT", "TIMEOUT", "STATES.TIMEOUT")):
+        return _TIMED_OUT
+    elif any(token in serialized for token in ("STOPPED", "ABORTED", "CANCELLED", "CANCELED")):
+        return _STOPPED
+    elif any(token in serialized for token in ("FAILED", "FAULT")):
+        return _FAILED
+    else:
+        return _TERMINAL_RESULT_MISSING
+
+
+def _fallback_error(terminal_context: dict[str, Any]) -> str:
+    classification = _classify_terminal_context(terminal_context)
+    context_json = json.dumps(terminal_context, sort_keys=True, separators=(",", ":"))
+    return f"{classification}: terminal_context={context_json}"
+
+
+def handler(event: dict[str, Any], context: Any = None) -> dict[str, str]:
+    """Atomically create a failed result, or preserve the worker's existing result."""
+    del context
+
+    trigger_id = _require_non_empty_string(event, "trigger_id")
+    done_endpoint = _require_non_empty_string(event, "done_endpoint")
+    terminal_context = _require_terminal_context(event)
+    bucket, key = _parse_s3_uri(done_endpoint)
+
+    result = ExecutionResult(
+        trigger_id=trigger_id,
+        status="failed",
+        steps=[],
+        error=_fallback_error(terminal_context),
+    )
+    body = json.dumps(result.to_dict(), indent=2).encode("utf-8")
+    s3_client = boto3.client("s3")
+
+    try:
+        s3_client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=body,
+            ContentType="application/json",
+            IfNoneMatch="*",
+        )
+    except ClientError as exc:
+        error_code = exc.response["Error"]["Code"]
+        if error_code in ("PreconditionFailed", "412"):
+            return {"status": "preserved", "trigger_id": trigger_id}
+        raise
+
+    return {"status": "created", "trigger_id": trigger_id}

--- a/aws_exe_sys/init_job/dispatcher.py
+++ b/aws_exe_sys/init_job/dispatcher.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import uuid
 
 import boto3
 
@@ -44,22 +45,19 @@ def dispatch_to_lambda(payload: SimplePayload) -> dict:
 
 
 def dispatch_to_codebuild(payload: SimplePayload) -> dict:
-    """Start a CodeBuild build with all 7 payload fields as env vars."""
-    project_name = os.environ["AWS_EXE_SYS_CODEBUILD_PROJECT"]
-    client = boto3.client("codebuild")
+    """Start the Standard workflow that owns the CodeBuild lifecycle."""
+    state_machine_arn = os.environ["AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN"]
+    client = boto3.client("stepfunctions")
+    execution_name = f"aws-exe-{uuid.uuid4().hex}"
 
-    env_overrides = [
-        {"name": field.upper(), "value": value, "type": "PLAINTEXT"}
-        for field, value in _payload_to_dict(payload).items()
-    ]
-
-    response = client.start_build(
-        projectName=project_name,
-        environmentVariablesOverride=env_overrides,
+    response = client.start_execution(
+        stateMachineArn=state_machine_arn,
+        name=execution_name,
+        input=json.dumps(_payload_to_dict(payload)),
     )
     logger.info(
-        "Dispatched to CodeBuild",
-        extra={"project": project_name, "trigger_id": payload.trigger_id},
+        "Dispatched CodeBuild workflow",
+        extra={"state_machine": state_machine_arn, "trigger_id": payload.trigger_id},
     )
     return response
 

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -16,6 +16,7 @@ RUN python3 -m pip install -r requirements.txt -r requirements-test.txt --target
 # Copy source and tests
 COPY aws_exe_sys/ ${LAMBDA_TASK_ROOT}/aws_exe_sys/
 COPY tests/ ${LAMBDA_TASK_ROOT}/tests/
+COPY infra/02-deploy/step_functions.tf ${LAMBDA_TASK_ROOT}/infra/02-deploy/step_functions.tf
 
 # Copy CONTRACT.md, CLAUDE.md, and docs/ so contract-drift guards can compare docs to code
 COPY CONTRACT.md ${LAMBDA_TASK_ROOT}/CONTRACT.md

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,14 +5,21 @@ This repository implements a minimal, provider-agnostic executor.
 ## Components
 
 - **`init_job`** (`aws_exe_sys.init_job`):
-  - accepts a `SimplePayload`
-  - validates the payload and required resources
-  - dispatches to an execution target
+  - accepts and validates a `SimplePayload`
+  - dispatches Lambda work directly or starts the CodeBuild workflow
 - **`worker`** (`aws_exe_sys.worker`):
   - fetches and unpacks `s3_package_uri`
   - decrypts optional secrets (`sops_type`)
-  - runs command list from `commands_b64`
-  - writes a terminal `ExecutionResult` to `done_endpoint`
+  - runs the command list from `commands_b64`
+  - writes the detailed terminal `ExecutionResult` to `done_endpoint`
+- **CodeBuild workflow** (Standard Step Functions):
+  - starts CodeBuild with all seven payload fields as plaintext environment overrides
+  - waits for CodeBuild to reach a terminal state
+  - invokes the finalizer on both success and caught failure
+- **`finalizer`** (`aws_exe_sys.finalizer`):
+  - atomically writes a failed fallback with `If-None-Match: *`
+  - treats S3 precondition failure as proof that the worker result exists
+  - propagates every other S3 failure
 
 ## Execution flow
 
@@ -21,18 +28,27 @@ caller
   -> init_job
       validate payload + references
       dispatch by execution_target
-         -> lambda worker / codebuild job
-             -> worker executes shell commands
-                 -> write done marker (S3)
+         -> lambda worker
+              -> detailed ExecutionResult -> done_endpoint
+         -> Standard Step Functions workflow
+              -> CodeBuild StartBuild.sync
+                   -> worker attempts detailed ExecutionResult
+              -> finalizer
+                   -> preserve existing marker, or create failed fallback
 ```
 
 ## Target matrix
 
-| execution_target | `init_job` behavior |
-| --- | --- |
-| `lambda` | async Lambda invoke |
-| `codebuild` | start CodeBuild build |
+| `execution_target` | `init_job` behavior | Lifecycle owner |
+| --- | --- | --- |
+| `lambda` | asynchronous Lambda invoke | worker Lambda |
+| `codebuild` | asynchronous Step Functions `StartExecution` | Standard workflow |
 
-### Completion contract
+For CodeBuild, `init_job` acknowledgement means only that Step Functions accepted the execution. The caller
+still waits for `done_endpoint`; Step Functions history is operational metadata, not a completion API.
 
-`done_endpoint` being present is the only completion marker. Presence means execution has finished and must include one `ExecutionResult` JSON document.
+## Completion contract
+
+Presence of `done_endpoint` is the only completion marker. The worker is always the primary writer. The
+finalizer never overwrites that result. A successful CodeBuild run without a worker marker becomes a canonical
+failed result because the completion contract was not satisfied.

--- a/docs/ARCHITECTURE_DIAGRAM.md
+++ b/docs/ARCHITECTURE_DIAGRAM.md
@@ -6,13 +6,26 @@ caller / producer
     v
   [init_job]
     | dispatch (lambda|codebuild)
-    +-------------------+
-    |                   |
-    v                   v
- [worker Lambda]    [CodeBuild worker]
-    \___________________/
-             |
-             v
-      write `ExecutionResult`
-       to `done_endpoint`
+    +----------------------+------------------------------+
+    |                                                     |
+    v                                                     v
+ [worker Lambda]                           [Standard Step Functions]
+    |                                                     |
+    |                                          CodeBuild StartBuild.sync
+    |                                                     |
+    |                                             [CodeBuild worker]
+    |                                                     |
+    |                                      detailed result attempt
+    |                                                     |
+    |                                             [finalizer Lambda]
+    |                                                     |
+    |                              conditional PutObject If-None-Match: *
+    |                                                     |
+    +----------------------+------------------------------+
+                           |
+                           v
+                  `done_endpoint` in S3
 ```
+
+The finalizer preserves an existing worker result. It creates only a missing failed fallback and propagates
+all non-precondition S3 errors.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -5,7 +5,7 @@ The repo includes Terraform in `infra/` for deploying the generic engine API.
 ## Directory layout
 
 - `infra/00-bootstrap`: S3 state backend bucket.
-- `infra/02-deploy`: Lambda, API Gateway, S3 buckets, IAM, and CodeBuild resources.
+- `infra/02-deploy`: Lambda, API Gateway, S3, IAM, CodeBuild, and Step Functions resources.
 
 ## Minimal local flow
 
@@ -14,6 +14,8 @@ The repo includes Terraform in `infra/` for deploying the generic engine API.
    ```bash
    bash scripts/build-release-zip.sh
    ```
+
+   `engine.zip` contains all three handlers: `init_job`, `worker`, and `finalizer`.
 
 2. Prepare the engine artifact references:
    - `project_prefix`
@@ -40,9 +42,32 @@ terraform init
 terraform apply
 ```
 
-By default, the deployed roles read packages from `<project_prefix>-internal` and write results to
+By default, deployed roles read packages from `<project_prefix>-internal` and write results to
 `<project_prefix>-done`. Configure the additional bucket ARN lists when payloads use other buckets.
 
-If you do not use the Terraform deployment, you can still invoke `init_job`/`worker` directly in AWS.
+## CodeBuild orchestration
+
+Deployments provision:
+
+- `<project_prefix>-codebuild`: Standard Step Functions state machine
+- `<project_prefix>-worker`: managed CodeBuild worker project
+- `<project_prefix>-finalizer`: missing-result fallback Lambda
+
+Terraform wires `AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN` into `init_job`. CodeBuild submission is accepted
+when `StartExecution` succeeds. The workflow then waits for CodeBuild and invokes the finalizer. The worker
+writes the detailed result; the finalizer only conditionally creates a missing failed result.
+
+Useful outputs are `codebuild_state_machine_arn`, `codebuild_state_machine_name`, and
+`finalizer_function_name`. These are operator metadata and are not caller payload fields.
+
+For a safe rollout, first deploy and directly test the finalizer and state machine, then update the `init_job`
+environment/role and publish the dispatcher switch. For rollback, restore direct CodeBuild dispatch and its
+scoped `codebuild:StartBuild` permission; do not alter existing terminal markers.
+
+If you do not use the Terraform deployment, you must provision the state machine/finalizer and set the two
+dispatch environment variables yourself:
+
+- `AWS_EXE_SYS_WORKER_LAMBDA`
+- `AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN`
 
 See `infra/` for full module details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,10 @@
 # aws-exe-sys docs
 
-A generic AWS execution interface with two runtime components:
+A generic AWS execution interface with three Lambda entry points:
 
 - `init_job`: validates and dispatches work requests.
 - `worker`: executes shell-command payloads on Lambda or CodeBuild.
+- `finalizer`: creates only a missing failed result after a terminal CodeBuild run.
 
 ## Main contracts
 

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -13,7 +13,9 @@ aws-exe-sys/
 │   ├── init_job/
 │   │   ├── handler.py          # API/Lambda entry for dispatch
 │   │   ├── validate.py         # preflight resource checks
-│   │   └── dispatcher.py       # lambda/codebuild dispatch targets
+│   │   └── dispatcher.py       # Lambda/Step Functions dispatch targets
+│   ├── finalizer/
+│   │   └── handler.py          # atomic missing-result fallback
 │   └── worker/
 │       ├── handler.py          # worker Lambda entry
 │       ├── run.py              # execute payload commands and write result
@@ -37,3 +39,4 @@ aws-exe-sys/
 
 - `aws_exe_sys.init_job.handler.handler`
 - `aws_exe_sys.worker.handler.handler`
+- `aws_exe_sys.finalizer.handler.handler`

--- a/infra/02-deploy/iam.tf
+++ b/infra/02-deploy/iam.tf
@@ -59,8 +59,8 @@ resource "aws_iam_role_policy" "init_job" {
       },
       {
         Effect   = "Allow"
-        Action   = ["codebuild:StartBuild"]
-        Resource = aws_codebuild_project.worker.arn
+        Action   = ["states:StartExecution"]
+        Resource = aws_sfn_state_machine.codebuild.arn
       },
     ]
   })
@@ -126,6 +126,40 @@ resource "aws_iam_role_policy" "worker" {
 resource "aws_iam_role_policy" "worker_logs" {
   name   = "logs"
   role   = aws_iam_role.worker.id
+  policy = data.aws_iam_policy_document.lambda_logs.json
+}
+
+# ============================================================
+# finalizer
+# ============================================================
+
+resource "aws_iam_role" "finalizer" {
+  name               = "${local.prefix}-finalizer"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+}
+
+resource "aws_iam_role_policy" "finalizer" {
+  name = "${local.prefix}-finalizer"
+  role = aws_iam_role.finalizer.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = ["s3:PutObject"]
+        Resource = concat(
+          ["${aws_s3_bucket.done.arn}/*"],
+          [for arn in var.additional_result_bucket_arns : "${arn}/*"],
+        )
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "finalizer_logs" {
+  name   = "logs"
+  role   = aws_iam_role.finalizer.id
   policy = data.aws_iam_policy_document.lambda_logs.json
 }
 

--- a/infra/02-deploy/lambdas.tf
+++ b/infra/02-deploy/lambdas.tf
@@ -23,8 +23,8 @@ resource "aws_lambda_function" "init_job" {
     variables = merge(
       local.lambda_env,
       {
-        AWS_EXE_SYS_WORKER_LAMBDA     = "${local.prefix}-worker"
-        AWS_EXE_SYS_CODEBUILD_PROJECT = aws_codebuild_project.worker.name
+        AWS_EXE_SYS_WORKER_LAMBDA               = "${local.prefix}-worker"
+        AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN = aws_sfn_state_machine.codebuild.arn
       },
     )
   }
@@ -33,6 +33,21 @@ resource "aws_lambda_function" "init_job" {
 resource "aws_lambda_function_url" "init_job" {
   function_name      = aws_lambda_function.init_job.function_name
   authorization_type = "AWS_IAM"
+}
+
+# --- finalizer: atomically creates only a missing failed CodeBuild result. ---
+
+resource "aws_lambda_function" "finalizer" {
+  function_name = "${local.prefix}-finalizer"
+  role          = aws_iam_role.finalizer.arn
+  package_type  = "Zip"
+  s3_bucket     = var.engine_zip_s3_bucket
+  s3_key        = var.engine_zip_s3_key
+  handler       = "aws_exe_sys.finalizer.handler.handler"
+  runtime       = "python3.14"
+  architectures = ["x86_64"]
+  timeout       = 30
+  memory_size   = 128
 }
 
 # --- worker: executes payload commands and decrypts optional SOPS payloads. ---

--- a/infra/02-deploy/main.tf
+++ b/infra/02-deploy/main.tf
@@ -10,6 +10,7 @@ terraform {
 }
 
 data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
 data "aws_region" "current" {}
 
 locals {

--- a/infra/02-deploy/outputs.tf
+++ b/infra/02-deploy/outputs.tf
@@ -16,16 +16,18 @@ output "api_gateway_id" {
 output "lambda_function_names" {
   description = "Map of Lambda function names"
   value = {
-    init_job = aws_lambda_function.init_job.function_name
-    worker   = aws_lambda_function.worker.function_name
+    init_job  = aws_lambda_function.init_job.function_name
+    worker    = aws_lambda_function.worker.function_name
+    finalizer = aws_lambda_function.finalizer.function_name
   }
 }
 
 output "lambda_function_arns" {
   description = "Map of Lambda function ARNs"
   value = {
-    init_job = aws_lambda_function.init_job.arn
-    worker   = aws_lambda_function.worker.arn
+    init_job  = aws_lambda_function.init_job.arn
+    worker    = aws_lambda_function.worker.arn
+    finalizer = aws_lambda_function.finalizer.arn
   }
 }
 
@@ -52,6 +54,21 @@ output "worker_function_name" {
 output "worker_function_arn" {
   description = "worker Lambda function ARN"
   value       = aws_lambda_function.worker.arn
+}
+
+output "finalizer_function_name" {
+  description = "CodeBuild result finalizer Lambda function name"
+  value       = aws_lambda_function.finalizer.function_name
+}
+
+output "codebuild_state_machine_arn" {
+  description = "CodeBuild orchestration state machine ARN"
+  value       = aws_sfn_state_machine.codebuild.arn
+}
+
+output "codebuild_state_machine_name" {
+  description = "CodeBuild orchestration state machine name"
+  value       = aws_sfn_state_machine.codebuild.name
 }
 
 output "s3_bucket_names" {

--- a/infra/02-deploy/step_functions.tf
+++ b/infra/02-deploy/step_functions.tf
@@ -1,0 +1,152 @@
+resource "aws_iam_role" "codebuild_workflow" {
+  name = "${local.prefix}-codebuild-workflow"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "states.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "codebuild_workflow" {
+  name = "${local.prefix}-codebuild-workflow"
+  role = aws_iam_role.codebuild_workflow.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "codebuild:StartBuild",
+          "codebuild:StopBuild",
+          "codebuild:BatchGetBuilds",
+        ]
+        Resource = aws_codebuild_project.worker.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "events:PutTargets",
+          "events:PutRule",
+          "events:DescribeRule",
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:events:${local.region}:${local.account_id}:rule/StepFunctionsGetEventForCodeBuildStartBuildRule"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["lambda:InvokeFunction"]
+        Resource = aws_lambda_function.finalizer.arn
+      },
+    ]
+  })
+}
+
+resource "aws_sfn_state_machine" "codebuild" {
+  name     = "${local.prefix}-codebuild"
+  role_arn = aws_iam_role.codebuild_workflow.arn
+  type     = "STANDARD"
+
+  definition = jsonencode({
+    Comment = "Run the execution-engine CodeBuild worker and guarantee a terminal S3 result"
+    StartAt = "RunCodeBuild"
+    States = {
+      RunCodeBuild = {
+        Type     = "Task"
+        Resource = "arn:${data.aws_partition.current.partition}:states:::codebuild:startBuild.sync"
+        Parameters = {
+          ProjectName = aws_codebuild_project.worker.name
+          EnvironmentVariablesOverride = [
+            {
+              Name      = "TRIGGER_ID"
+              "Value.$" = "$.trigger_id"
+              Type      = "PLAINTEXT"
+            },
+            {
+              Name      = "S3_PACKAGE_URI"
+              "Value.$" = "$.s3_package_uri"
+              Type      = "PLAINTEXT"
+            },
+            {
+              Name      = "SOPS_TYPE"
+              "Value.$" = "$.sops_type"
+              Type      = "PLAINTEXT"
+            },
+            {
+              Name      = "SOPS_PATH"
+              "Value.$" = "$.sops_path"
+              Type      = "PLAINTEXT"
+            },
+            {
+              Name      = "COMMANDS_B64"
+              "Value.$" = "$.commands_b64"
+              Type      = "PLAINTEXT"
+            },
+            {
+              Name      = "DONE_ENDPOINT"
+              "Value.$" = "$.done_endpoint"
+              Type      = "PLAINTEXT"
+            },
+            {
+              Name      = "EXECUTION_TARGET"
+              "Value.$" = "$.execution_target"
+              Type      = "PLAINTEXT"
+            },
+          ]
+        }
+        ResultSelector = {
+          outcome = "succeeded"
+        }
+        ResultPath = "$.terminal_context"
+        Catch = [
+          {
+            ErrorEquals = ["States.ALL"]
+            ResultPath  = "$.terminal_context"
+            Next        = "FinalizeResult"
+          },
+        ]
+        Next = "FinalizeResult"
+      }
+      FinalizeResult = {
+        Type     = "Task"
+        Resource = "arn:${data.aws_partition.current.partition}:states:::lambda:invoke"
+        Parameters = {
+          FunctionName = aws_lambda_function.finalizer.arn
+          Payload = {
+            "trigger_id.$"       = "$.trigger_id"
+            "done_endpoint.$"    = "$.done_endpoint"
+            "terminal_context.$" = "$.terminal_context"
+          }
+        }
+        Retry = [
+          {
+            ErrorEquals = [
+              "Lambda.ServiceException",
+              "Lambda.AWSLambdaException",
+              "Lambda.SdkClientException",
+              "Lambda.TooManyRequestsException",
+            ]
+            IntervalSeconds = 2
+            MaxAttempts     = 3
+            BackoffRate     = 2
+          },
+          {
+            ErrorEquals     = ["States.TaskFailed"]
+            IntervalSeconds = 2
+            MaxAttempts     = 2
+            BackoffRate     = 2
+          },
+        ]
+        OutputPath = "$.Payload"
+        End        = true
+      }
+    }
+  })
+}

--- a/scripts/build-release-zip.sh
+++ b/scripts/build-release-zip.sh
@@ -108,6 +108,7 @@ engine_path = Path(sys.argv[1])
 layer_path = Path(sys.argv[2])
 
 required_engine = {
+    "aws_exe_sys/finalizer/handler.py",
     "aws_exe_sys/init_job/handler.py",
     "aws_exe_sys/worker/handler.py",
     "boto3/__init__.py",
@@ -132,7 +133,7 @@ docker run --rm \
 	-e PYTHONPATH=/artifacts/engine.zip \
 	-v "$DIST_DIR:/artifacts:ro" \
 	public.ecr.aws/lambda/python:3.14 \
-	-c 'from aws_exe_sys.init_job.handler import handler as init_job_handler; from aws_exe_sys.worker.handler import handler as worker_handler; assert callable(init_job_handler) and callable(worker_handler)'
+	-c 'from aws_exe_sys.finalizer.handler import handler as finalizer_handler; from aws_exe_sys.init_job.handler import handler as init_job_handler; from aws_exe_sys.worker.handler import handler as worker_handler; assert callable(finalizer_handler) and callable(init_job_handler) and callable(worker_handler)'
 
 printf '%s\n' "=== Release artifacts ==="
 for artifact in "$DIST_DIR/engine.zip" "$DIST_DIR/sops-age-layer.zip"; do

--- a/tests/integration/test_simplified_init.py
+++ b/tests/integration/test_simplified_init.py
@@ -78,7 +78,8 @@ class TestInitValidPayloadDispatch:
         assert len(sent) == 7
 
     def test_dispatch_to_codebuild(self, monkeypatch):
-        monkeypatch.setenv("AWS_EXE_SYS_CODEBUILD_PROJECT", "my-cb-project")
+        state_machine_arn = "arn:aws:states:us-east-1:123:stateMachine:xe"
+        monkeypatch.setenv("AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN", state_machine_arn)
 
         mock_s3 = MagicMock()
         mock_s3.head_object.return_value = {}
@@ -86,25 +87,26 @@ class TestInitValidPayloadDispatch:
         mock_ssm = MagicMock()
         mock_ssm.get_parameter.return_value = {"Parameter": {"Value": "age-key"}}
 
-        mock_cb = MagicMock()
-        mock_cb.start_build.return_value = {"build": {"id": "build-123"}}
+        mock_stepfunctions = MagicMock()
+        mock_stepfunctions.start_execution.return_value = {"executionArn": "execution-arn"}
 
         with (
             patch("aws_exe_sys.init_job.validate.boto3") as mock_val_boto3,
             patch("aws_exe_sys.init_job.dispatcher.boto3") as mock_disp_boto3,
         ):
             mock_val_boto3.client.side_effect = _mock_boto3_client({"s3": mock_s3, "ssm": mock_ssm})
-            mock_disp_boto3.client.return_value = mock_cb
+            mock_disp_boto3.client.return_value = mock_stepfunctions
 
             result = handler(_valid_event(execution_target="codebuild"))
 
-        assert result["status"] == "ok"
-        mock_cb.start_build.assert_called_once()
-        call_kwargs = mock_cb.start_build.call_args[1]
-        assert call_kwargs["projectName"] == "my-cb-project"
-        env_names = {e["name"] for e in call_kwargs["environmentVariablesOverride"]}
-        assert "TRIGGER_ID" in env_names
-        assert len(env_names) == 7
+        assert result == {"status": "ok", "trigger_id": "trg-int-001"}
+        mock_stepfunctions.start_execution.assert_called_once()
+        call_kwargs = mock_stepfunctions.start_execution.call_args.kwargs
+        assert call_kwargs["stateMachineArn"] == state_machine_arn
+        sent = json.loads(call_kwargs["input"])
+        assert set(sent) == set(_valid_event())
+        assert all(isinstance(value, str) for value in sent.values())
+        mock_stepfunctions.start_build.assert_not_called()
 
 
 class TestInitInvalidPayload:

--- a/tests/smoke/test_deploy.sh
+++ b/tests/smoke/test_deploy.sh
@@ -23,7 +23,7 @@ done
 INTERNAL_BUCKET="${PREFIX}-internal"
 DONE_BUCKET="${PREFIX}-done"
 
-for SUFFIX in init-job worker; do
+for SUFFIX in init-job worker finalizer; do
 	FUNC="${PREFIX}-${SUFFIX}"
 	if aws lambda get-function --function-name "$FUNC" --region "$AWS_REGION" >/dev/null 2>&1; then
 		pass "Lambda $FUNC exists"
@@ -44,6 +44,12 @@ if aws codebuild batch-get-projects --names "${PREFIX}-worker" --region "$AWS_RE
 	pass "CodeBuild project ${PREFIX}-worker exists"
 else
 	fail "CodeBuild project ${PREFIX}-worker not found"
+fi
+
+if aws stepfunctions describe-state-machine --state-machine-arn "arn:aws:states:${AWS_REGION}:$(aws sts get-caller-identity --query Account --output text):stateMachine:${PREFIX}-codebuild" --region "$AWS_REGION" >/dev/null 2>&1; then
+	pass "Step Functions state machine ${PREFIX}-codebuild exists"
+else
+	fail "Step Functions state machine ${PREFIX}-codebuild not found"
 fi
 
 echo ""

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -99,53 +99,63 @@ class TestDispatchToLambda:
 
 
 class TestDispatchToCodeBuild:
+    @patch("aws_exe_sys.init_job.dispatcher.uuid.uuid4")
     @patch("aws_exe_sys.init_job.dispatcher.boto3")
-    def test_starts_codebuild_project(self, mock_boto3, monkeypatch):
-        monkeypatch.setenv("AWS_EXE_SYS_CODEBUILD_PROJECT", "my-cb-project")
+    def test_starts_standard_workflow(self, mock_boto3, mock_uuid4, monkeypatch):
+        monkeypatch.setenv("AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN", "arn:aws:states:us-east-1:123:stateMachine:xe")
+        mock_uuid4.return_value.hex = "unique123"
 
         mock_client = MagicMock()
-        mock_client.start_build.return_value = {"build": {"id": "build-123"}}
+        mock_client.start_execution.return_value = {"executionArn": "arn:aws:states:us-east-1:123:execution:xe:run"}
         mock_boto3.client.return_value = mock_client
 
         payload = _valid_payload(execution_target="codebuild")
         response = dispatch_to_codebuild(payload)
 
-        assert "build" in response
-        mock_boto3.client.assert_called_once_with("codebuild")
-        mock_client.start_build.assert_called_once()
+        assert "executionArn" in response
+        mock_boto3.client.assert_called_once_with("stepfunctions")
+        mock_client.start_execution.assert_called_once()
+        mock_client.start_build.assert_not_called()
 
+    @patch("aws_exe_sys.init_job.dispatcher.uuid.uuid4")
     @patch("aws_exe_sys.init_job.dispatcher.boto3")
-    def test_passes_all_7_fields_as_env_vars(self, mock_boto3, monkeypatch):
-        monkeypatch.setenv("AWS_EXE_SYS_CODEBUILD_PROJECT", "my-cb-project")
+    def test_passes_exactly_7_plain_string_fields(self, mock_boto3, mock_uuid4, monkeypatch):
+        state_machine_arn = "arn:aws:states:us-east-1:123:stateMachine:xe"
+        monkeypatch.setenv("AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN", state_machine_arn)
+        mock_uuid4.return_value.hex = "unique123"
 
         mock_client = MagicMock()
-        mock_client.start_build.return_value = {"build": {"id": "build-123"}}
+        mock_client.start_execution.return_value = {"executionArn": "execution-arn"}
         mock_boto3.client.return_value = mock_client
 
-        payload = _valid_payload(execution_target="codebuild")
+        payload = _valid_payload(execution_target="codebuild", sops_type=None, sops_path=None)
         dispatch_to_codebuild(payload)
 
-        call_kwargs = mock_client.start_build.call_args[1]
-        assert call_kwargs["projectName"] == "my-cb-project"
-
-        env_vars = call_kwargs["environmentVariablesOverride"]
-        env_names = {e["name"] for e in env_vars}
-        expected = {
-            "TRIGGER_ID",
-            "S3_PACKAGE_URI",
-            "SOPS_TYPE",
-            "SOPS_PATH",
-            "COMMANDS_B64",
-            "DONE_ENDPOINT",
-            "EXECUTION_TARGET",
+        call_kwargs = mock_client.start_execution.call_args.kwargs
+        assert call_kwargs["stateMachineArn"] == state_machine_arn
+        assert call_kwargs["name"] == "aws-exe-unique123"
+        sent_payload = json.loads(call_kwargs["input"])
+        assert set(sent_payload) == {
+            "trigger_id",
+            "s3_package_uri",
+            "sops_type",
+            "sops_path",
+            "commands_b64",
+            "done_endpoint",
+            "execution_target",
         }
-        assert env_names == expected
+        assert all(isinstance(value, str) for value in sent_payload.values())
+        assert sent_payload["sops_type"] == ""
+        assert sent_payload["sops_path"] == ""
 
-        # Verify values
-        env_map = {e["name"]: e["value"] for e in env_vars}
-        assert env_map["TRIGGER_ID"] == "trg-001"
-        assert env_map["S3_PACKAGE_URI"] == "s3://my-bucket/exec/trg-001/exec.zip"
-        assert all(e["type"] == "PLAINTEXT" for e in env_vars)
+    @patch("aws_exe_sys.init_job.dispatcher.boto3")
+    def test_missing_state_machine_configuration_fails_loudly(self, mock_boto3, monkeypatch):
+        monkeypatch.delenv("AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN", raising=False)
+
+        with pytest.raises(KeyError, match="AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN"):
+            dispatch_to_codebuild(_valid_payload(execution_target="codebuild"))
+
+        mock_boto3.client.assert_not_called()
 
 
 class TestDispatchRouting:
@@ -162,16 +172,17 @@ class TestDispatchRouting:
         mock_client.invoke.assert_called_once()
 
     @patch("aws_exe_sys.init_job.dispatcher.boto3")
-    def test_routes_to_codebuild(self, mock_boto3, monkeypatch):
-        monkeypatch.setenv("AWS_EXE_SYS_CODEBUILD_PROJECT", "my-cb-project")
+    def test_routes_to_codebuild_workflow(self, mock_boto3, monkeypatch):
+        monkeypatch.setenv("AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN", "arn:aws:states:us-east-1:123:stateMachine:xe")
         mock_client = MagicMock()
-        mock_client.start_build.return_value = {"build": {"id": "build-1"}}
+        mock_client.start_execution.return_value = {"executionArn": "execution-arn"}
         mock_boto3.client.return_value = mock_client
 
         payload = _valid_payload(execution_target="codebuild")
         result = dispatch(payload)
-        assert "build" in result
-        mock_client.start_build.assert_called_once()
+        assert "executionArn" in result
+        mock_client.start_execution.assert_called_once()
+        mock_client.start_build.assert_not_called()
 
     def test_unknown_target_raises(self):
         payload = _valid_payload(execution_target="ecs")

--- a/tests/unit/test_finalizer_handler.py
+++ b/tests/unit/test_finalizer_handler.py
@@ -1,0 +1,143 @@
+"""Unit tests for the CodeBuild terminal-result finalizer."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import boto3
+from botocore.exceptions import ClientError
+from moto import mock_aws
+import pytest
+
+from aws_exe_sys.finalizer import handler as finalizer_handler
+
+
+@pytest.fixture
+def aws_env(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+
+
+@pytest.fixture
+def s3_client(aws_env):
+    with mock_aws():
+        client = boto3.client("s3", region_name="us-east-1")
+        client.create_bucket(Bucket="done-bucket")
+        yield client
+
+
+def _event(terminal_context: dict | None = None, **overrides) -> dict:
+    if terminal_context is None:
+        terminal_context = {"outcome": "succeeded"}
+    event = {
+        "trigger_id": "trg-001",
+        "done_endpoint": "s3://done-bucket/trg-001/result.json",
+        "terminal_context": terminal_context,
+    }
+    event.update(overrides)
+    return event
+
+
+def _read_result(s3_client) -> dict:
+    response = s3_client.get_object(Bucket="done-bucket", Key="trg-001/result.json")
+    return json.loads(response["Body"].read().decode("utf-8"))
+
+
+def test_missing_marker_creates_failed_execution_result(s3_client):
+    with patch("aws_exe_sys.finalizer.handler.boto3.client", return_value=s3_client):
+        response = finalizer_handler.handler(_event({"Error": "CodeBuild.BuildFailed", "Cause": "build FAILED"}))
+
+    assert response == {"status": "created", "trigger_id": "trg-001"}
+    result = _read_result(s3_client)
+    assert result["trigger_id"] == "trg-001"
+    assert result["status"] == "failed"
+    assert result["steps"] == []
+    assert result["error"].startswith("codebuild_failed_without_result:")
+
+
+def test_existing_worker_marker_is_preserved(s3_client):
+    worker_result = b'{"trigger_id":"trg-001","status":"succeeded","steps":[]}'
+    s3_client.put_object(Bucket="done-bucket", Key="trg-001/result.json", Body=worker_result)
+
+    with patch("aws_exe_sys.finalizer.handler.boto3.client", return_value=s3_client):
+        response = finalizer_handler.handler(_event())
+
+    assert response == {"status": "preserved", "trigger_id": "trg-001"}
+    stored = s3_client.get_object(Bucket="done-bucket", Key="trg-001/result.json")["Body"].read()
+    assert stored == worker_result
+
+
+def test_success_without_marker_is_failed_contract_outcome(s3_client):
+    with patch("aws_exe_sys.finalizer.handler.boto3.client", return_value=s3_client):
+        finalizer_handler.handler(_event({"outcome": "succeeded"}))
+
+    assert _read_result(s3_client)["error"].startswith("codebuild_succeeded_without_result:")
+
+
+@pytest.mark.parametrize(
+    ("terminal_context", "classification"),
+    [
+        ({"Error": "CodeBuild.BuildFailed", "Cause": "BuildStatus=FAILED"}, "codebuild_failed_without_result"),
+        ({"Error": "CodeBuild.BuildFailed", "Cause": "BuildStatus=STOPPED"}, "codebuild_stopped_without_result"),
+        ({"Error": "CodeBuild.BuildFailed", "Cause": "BuildStatus=TIMED_OUT"}, "codebuild_timed_out_without_result"),
+        ({"Error": "UnknownTerminalError", "Cause": "no build status"}, "codebuild_terminal_result_missing"),
+    ],
+)
+def test_terminal_context_has_stable_classification(s3_client, terminal_context, classification):
+    with patch("aws_exe_sys.finalizer.handler.boto3.client", return_value=s3_client):
+        finalizer_handler.handler(_event(terminal_context))
+
+    assert _read_result(s3_client)["error"].startswith(f"{classification}:")
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        _event(done_endpoint=""),
+        _event(done_endpoint="not-an-s3-uri"),
+        {"trigger_id": "trg-001", "terminal_context": {"outcome": "succeeded"}},
+    ],
+)
+def test_invalid_or_missing_done_endpoint_fails_loudly(event):
+    with pytest.raises(ValueError, match="done_endpoint|Invalid S3 URI"):
+        finalizer_handler.handler(event)
+
+
+def test_non_precondition_s3_error_propagates():
+    s3_client = MagicMock()
+    s3_client.put_object.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+        "PutObject",
+    )
+
+    with (
+        patch("aws_exe_sys.finalizer.handler.boto3.client", return_value=s3_client),
+        pytest.raises(ClientError),
+    ):
+        finalizer_handler.handler(_event())
+
+
+def test_precondition_failure_is_success():
+    s3_client = MagicMock()
+    s3_client.put_object.side_effect = ClientError(
+        {"Error": {"Code": "PreconditionFailed", "Message": "exists"}},
+        "PutObject",
+    )
+
+    with patch("aws_exe_sys.finalizer.handler.boto3.client", return_value=s3_client):
+        response = finalizer_handler.handler(_event())
+
+    assert response["status"] == "preserved"
+
+
+def test_duplicate_invocation_is_idempotent(s3_client):
+    with patch("aws_exe_sys.finalizer.handler.boto3.client", return_value=s3_client):
+        first = finalizer_handler.handler(_event({"Error": "CodeBuild.BuildFailed", "Cause": "FAILED"}))
+        first_body = _read_result(s3_client)
+        second = finalizer_handler.handler(_event({"outcome": "succeeded"}))
+        second_body = _read_result(s3_client)
+
+    assert first["status"] == "created"
+    assert second["status"] == "preserved"
+    assert second_body == first_body

--- a/tests/unit/test_step_functions_terraform.py
+++ b/tests/unit/test_step_functions_terraform.py
@@ -1,0 +1,32 @@
+"""Contract tests for the CodeBuild Step Functions definition in Terraform."""
+
+from pathlib import Path
+
+STATE_MACHINE_TERRAFORM = Path(__file__).resolve().parents[2] / "infra" / "02-deploy" / "step_functions.tf"
+
+
+def test_state_machine_uses_standard_sync_codebuild_and_finalizer():
+    source = STATE_MACHINE_TERRAFORM.read_text()
+
+    assert 'type     = "STANDARD"' in source
+    assert "states:::codebuild:startBuild.sync" in source
+    assert 'Next        = "FinalizeResult"' in source
+    assert 'Resource = "arn:${data.aws_partition.current.partition}:states:::lambda:invoke"' in source
+    assert "IfNoneMatch" not in source
+
+
+def test_state_machine_passes_exactly_seven_plaintext_environment_overrides():
+    source = STATE_MACHINE_TERRAFORM.read_text()
+
+    expected_names = {
+        "TRIGGER_ID",
+        "S3_PACKAGE_URI",
+        "SOPS_TYPE",
+        "SOPS_PATH",
+        "COMMANDS_B64",
+        "DONE_ENDPOINT",
+        "EXECUTION_TARGET",
+    }
+    for name in expected_names:
+        assert source.count(f'Name      = "{name}"') == 1
+    assert source.count('Type      = "PLAINTEXT"') == 7


### PR DESCRIPTION
## Intent

Implement the approved /tmp/aws-exec-plan.md for aws-execution-engine while preserving the existing seven-field SimplePayload caller contract and Lambda dispatch path. Replace direct asynchronous CodeBuild dispatch with a Standard Step Functions workflow using codebuild:startBuild.sync, then invoke a finalizer Lambda that atomically creates a fallback ExecutionResult at done_endpoint only when the authoritative worker result is absent. Keep all seven payload fields as plain-string CodeBuild environment overrides; fail loudly on configuration, dispatch, validation, or result-write errors; scope IAM narrowly; package the finalizer in deterministic public release artifacts; update contract, architecture, deployment, and repository documentation; and add unit/integration/Terraform tests. Preserve unrelated .memsearch working-tree changes. The user has asked to validate and push the completed implementation.

## What Changed
- Replaced direct asynchronous CodeBuild dispatch with a Standard Step Functions path that starts CodeBuild synchronously, waits for terminal build state, and invokes a finalizer Lambda.
- Added the finalizer Lambda to create a failed fallback `ExecutionResult` at `done_endpoint` only when the worker result is absent, preserving the seven-field `SimplePayload` contract and plain-string CodeBuild environment overrides.
- Updated Terraform IAM/Lambda/Step Functions wiring, deterministic release packaging, documentation, and focused unit/integration/Terraform coverage for the new flow.

## Risk Assessment

✅ Low: The branch change is well-bounded and source review found the required Step Functions dispatch, atomic finalizer behavior, scoped IAM, packaging, and documentation updates without material defects.

## Testing

Inspected the diff and intent, ran focused changed-surface tests and the full pytest suite, captured a mocked caller-to-init_job-to-Step Functions/Lambda/finalizer S3 transcript, built public release artifacts twice with matching hashes, verified the finalizer and layer entries plus fixed timestamps in the archives, and removed transient `.build`, `dist`, pytest cache, and bytecode outputs from the worktree.

<details>
<summary>Evidence: CodeBuild Step Functions and finalizer behavior transcript</summary>

```text
{
  "caller_contract_fields": [
    "trigger_id",
    "s3_package_uri",
    "sops_type",
    "sops_path",
    "commands_b64",
    "done_endpoint",
    "execution_target"
  ],
  "codebuild_dispatch": {
    "all_input_values_are_strings": true,
    "boto3_service": "stepfunctions",
    "execution_name": "aws-exe-e2e001",
    "input": {
      "commands_b64": "WyJlY2hvIGhlbGxvIGZyb20gY29kZWJ1aWxkIl0=",
      "done_endpoint": "s3://done-bucket/trg-e2e-001/result.json",
      "execution_target": "codebuild",
      "s3_package_uri": "s3://packages/exec/trg-e2e-001/exec.zip",
      "sops_path": "/exe-sys/sops-keys/run1/001",
      "sops_type": "ssm",
      "trigger_id": "trg-e2e-001"
    },
    "input_field_count": 7,
    "start_build_called": false,
    "start_execution_called": true,
    "stateMachineArn": "arn:aws:states:us-east-1:123456789012:stateMachine:aws-exe-codebuild"
  },
  "codebuild_init_job_response": {
    "status": "ok",
    "trigger_id": "trg-e2e-001"
  },
  "finalizer_existing_worker_marker": {
    "persisted_s3_uri": "s3://done-bucket/trg-e2e-002/result.json",
    "response": {
      "status": "preserved",
      "trigger_id": "trg-e2e-002"
    },
    "stored_body_after_finalizer": {
      "status": "succeeded",
      "steps": [],
      "trigger_id": "trg-e2e-002"
    },
    "worker_body_preserved_byte_for_byte": true
  },
  "finalizer_missing_marker": {
    "persisted_result": {
      "error": "codebuild_failed_without_result: terminal_context={\"Cause\":\"BuildStatus=FAILED\",\"Error\":\"CodeBuild.BuildFailed\"}",
      "status": "failed",
      "steps": [],
      "trigger_id": "trg-e2e-001"
    },
    "persisted_s3_uri": "s3://done-bucket/trg-e2e-001/result.json",
    "response": {
      "status": "created",
      "trigger_id": "trg-e2e-001"
    }
  },
  "lambda_dispatch": {
    "FunctionName": "aws-exe-worker",
    "InvocationType": "Event",
    "all_payload_values_are_strings": true,
    "boto3_service": "lambda",
    "payload": {
      "commands_b64": "WyJlY2hvIGhlbGxvIGZyb20gY29kZWJ1aWxkIl0=",
      "done_endpoint": "s3://done-bucket/trg-e2e-001/result.json",
      "execution_target": "lambda",
      "s3_package_uri": "s3://packages/exec/trg-e2e-001/exec.zip",
      "sops_path": "/exe-sys/sops-keys/run1/001",
      "sops_type": "ssm",
      "trigger_id": "trg-e2e-001"
    },
    "payload_field_count": 7
  },
  "lambda_init_job_response": {
    "status": "ok",
    "trigger_id": "trg-e2e-001"
  },
  "terraform_workflow_contract": {
    "all_expected_override_names_once": true,
    "finalizer_lambda_invoke_declared": true,
    "plaintext_override_count": 7,
    "plaintext_override_names": [
      "TRIGGER_ID",
      "S3_PACKAGE_URI",
      "SOPS_TYPE",
      "SOPS_PATH",
      "COMMANDS_B64",
      "DONE_ENDPOINT",
      "EXECUTION_TARGET"
    ],
    "standard_state_machine_declared": true,
    "sync_codebuild_integration_declared": true
  }
}
```
</details>
<details>
<summary>Evidence: Release artifact manifest</summary>

```text
{
  "engine.zip": {
    "all_entries_use_source_date_epoch_1980_01_01": true,
    "entry_count": 2180,
    "missing_required_entries": [],
    "path_checked": "dist/engine.zip",
    "required_entries_present": [
      "aws_exe_sys/finalizer/handler.py",
      "aws_exe_sys/init_job/handler.py",
      "aws_exe_sys/worker/handler.py",
      "boto3/__init__.py"
    ],
    "selected_entry_timestamps": {
      "aws_exe_sys/finalizer/handler.py": [
        1980,
        1,
        1,
        0,
        0,
        0
      ],
      "aws_exe_sys/init_job/handler.py": [
        1980,
        1,
        1,
        0,
        0,
        0
      ],
      "aws_exe_sys/worker/handler.py": [
        1980,
        1,
        1,
        0,
        0,
        0
      ],
      "boto3/__init__.py": [
        1980,
        1,
        1,
        0,
        0,
        0
      ]
    },
    "size_bytes": 16112576
  },
  "sops-age-layer.zip": {
    "all_entries_use_source_date_epoch_1980_01_01": true,
    "entry_count": 3,
    "missing_required_entries": [],
    "path_checked": "dist/sops-age-layer.zip",
    "required_entries_present": [
      "bin/age",
      "bin/age-keygen",
      "bin/sops"
    ],
    "selected_entry_timestamps": {
      "bin/age": [
        1980,
        1,
        1,
        0,
        0,
        0
      ],
      "bin/age-keygen": [
        1980,
        1,
        1,
        0,
        0,
        0
      ],
      "bin/sops": [
        1980,
        1,
        1,
        0,
        0,
        0
      ]
    },
    "size_bytes": 18356660
  }
}
```
</details>
<details>
<summary>Evidence: Release artifact build log</summary>

```text
=== Build engine.zip ===
Collecting boto3>=1.34.0 (from -r /src/requirements.txt (line 1))
  Downloading boto3-1.43.59-py3-none-any.whl.metadata (6.6 kB)
Collecting botocore<1.44.0,>=1.43.59 (from boto3>=1.34.0->-r /src/requirements.txt (line 1))
  Downloading botocore-1.43.59-py3-none-any.whl.metadata (5.6 kB)
Collecting jmespath<2.0.0,>=0.7.1 (from boto3>=1.34.0->-r /src/requirements.txt (line 1))
  Downloading jmespath-1.1.0-py3-none-any.whl.metadata (7.6 kB)
Collecting s3transfer<0.20.0,>=0.19.0 (from boto3>=1.34.0->-r /src/requirements.txt (line 1))
  Downloading s3transfer-0.19.2-py3-none-any.whl.metadata (1.7 kB)
Collecting python-dateutil<3.0.0,>=2.1 (from botocore<1.44.0,>=1.43.59->boto3>=1.34.0->-r /src/requirements.txt (line 1))
  Downloading python_dateutil-2.9.0.post0-py2.py3-none-any.whl.metadata (8.4 kB)
Collecting urllib3!=2.2.0,<3,>=1.25.4 (from botocore<1.44.0,>=1.43.59->boto3>=1.34.0->-r /src/requirements.txt (line 1))
  Downloading urllib3-2.7.0-py3-none-any.whl.metadata (6.9 kB)
Collecting six>=1.5 (from python-dateutil<3.0.0,>=2.1->botocore<1.44.0,>=1.43.59->boto3>=1.34.0->-r /src/requirements.txt (line 1))
  Downloading six-1.17.0-py2.py3-none-any.whl.metadata (1.7 kB)
Downloading boto3-1.43.59-py3-none-any.whl (140 kB)
Downloading botocore-1.43.59-py3-none-any.whl (15.5 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 15.5/15.5 MB 1.8 MB/s  0:00:08
Downloading jmespath-1.1.0-py3-none-any.whl (20 kB)
Downloading python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)
Downloading s3transfer-0.19.2-py3-none-any.whl (90 kB)
Downloading urllib3-2.7.0-py3-none-any.whl (131 kB)
Downloading six-1.17.0-py2.py3-none-any.whl (11 kB)
Installing collected packages: urllib3, six, jmespath, python-dateutil, botocore, s3transfer, boto3

Successfully installed boto3-1.43.59 botocore-1.43.59 jmespath-1.1.0 python-dateutil-2.9.0.post0 s3transfer-0.19.2 six-1.17.0 urllib3-2.7.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
=== Build sops-age-layer.zip ===
=== Release artifacts ===
  /home/gary/.no-mistakes/worktrees/da03a667175d/01KYS1KXSVPNP34KDDT44QR422/dist/engine.zip (16112576 bytes)
  /home/gary/.no-mistakes/worktrees/da03a667175d/01KYS1KXSVPNP34KDDT44QR422/dist/sops-age-layer.zip (18356660 bytes)
```
</details>
<details>
<summary>Evidence: Repeat release artifact build log</summary>

```text
=== Build engine.zip ===
Collecting boto3>=1.34.0 (from -r /src/requirements.txt (line 1))
  Downloading boto3-1.43.59-py3-none-any.whl.metadata (6.6 kB)
Collecting botocore<1.44.0,>=1.43.59 (from boto3>=1.34.0->-r /src/requirements.txt (line 1))
  Downloading botocore-1.43.59-py3-none-any.whl.metadata (5.6 kB)
Collecting jmespath<2.0.0,>=0.7.1 (from boto3>=1.34.0->-r /src/requirements.txt (line 1))
  Downloading jmespath-1.1.0-py3-none-any.whl.metadata (7.6 kB)
Collecting s3transfer<0.20.0,>=0.19.0 (from boto3>=1.34.0->-r /src/requirements.txt (line 1))
  Downloading s3transfer-0.19.2-py3-none-any.whl.metadata (1.7 kB)
Collecting python-dateutil<3.0.0,>=2.1 (from botocore<1.44.0,>=1.43.59->boto3>=1.34.0->-r /src/requirements.txt (line 1))
  Downloading python_dateutil-2.9.0.post0-py2.py3-none-any.whl.metadata (8.4 kB)
Collecting urllib3!=2.2.0,<3,>=1.25.4 (from botocore<1.44.0,>=1.43.59->boto3>=1.34.0->-r /src/requirements.txt (line 1))
  Downloading urllib3-2.7.0-py3-none-any.whl.metadata (6.9 kB)
Collecting six>=1.5 (from python-dateutil<3.0.0,>=2.1->botocore<1.44.0,>=1.43.59->boto3>=1.34.0->-r /src/requirements.txt (line 1))
  Downloading six-1.17.0-py2.py3-none-any.whl.metadata (1.7 kB)
Downloading boto3-1.43.59-py3-none-any.whl (140 kB)
Downloading botocore-1.43.59-py3-none-any.whl (15.5 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 15.5/15.5 MB 1.7 MB/s  0:00:09
Downloading jmespath-1.1.0-py3-none-any.whl (20 kB)
Downloading python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)
Downloading s3transfer-0.19.2-py3-none-any.whl (90 kB)
Downloading urllib3-2.7.0-py3-none-any.whl (131 kB)
Downloading six-1.17.0-py2.py3-none-any.whl (11 kB)
Installing collected packages: urllib3, six, jmespath, python-dateutil, botocore, s3transfer, boto3

Successfully installed boto3-1.43.59 botocore-1.43.59 jmespath-1.1.0 python-dateutil-2.9.0.post0 s3transfer-0.19.2 six-1.17.0 urllib3-2.7.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
=== Build sops-age-layer.zip ===
=== Release artifacts ===
  /home/gary/.no-mistakes/worktrees/da03a667175d/01KYS1KXSVPNP34KDDT44QR422/dist/engine.zip (16112576 bytes)
  /home/gary/.no-mistakes/worktrees/da03a667175d/01KYS1KXSVPNP34KDDT44QR422/dist/sops-age-layer.zip (18356660 bytes)
```
</details>
<details>
<summary>Evidence: Release artifact hash comparison</summary>

<code>Both build runs produced identical hashes:&#10;6d9fe1ffc9953b9fedc118a6facc01a4e297a89a4ffe0601b41fb908d6b76a46 dist/engine.zip&#10;dfac2b32dea27e3852459156e34880323965c6aba8b7174645e88e8a31a577fd dist/sops-age-layer.zip</code>

```text
6d9fe1ffc9953b9fedc118a6facc01a4e297a89a4ffe0601b41fb908d6b76a46  dist/engine.zip
dfac2b32dea27e3852459156e34880323965c6aba8b7174645e88e8a31a577fd  dist/sops-age-layer.zip
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pytest tests/unit/test_dispatcher.py tests/unit/test_finalizer_handler.py tests/unit/test_step_functions_terraform.py tests/integration/test_simplified_init.py`
- `pytest`
- `python3 - <<'PY' > /tmp/no-mistakes-evidence/01KYS1KXSVPNP34KDDT44QR422/codebuild_stepfunctions_finalizer_evidence.json ...`
- `scripts/build-release-zip.sh 2>&1 | tee /tmp/no-mistakes-evidence/01KYS1KXSVPNP34KDDT44QR422/build_release_zip.log`
- `sha256sum dist/engine.zip dist/sops-age-layer.zip | tee /tmp/no-mistakes-evidence/01KYS1KXSVPNP34KDDT44QR422/release_artifact_hashes_first.txt`
- `scripts/build-release-zip.sh 2>&1 | tee /tmp/no-mistakes-evidence/01KYS1KXSVPNP34KDDT44QR422/build_release_zip_second.log`
- `sha256sum dist/engine.zip dist/sops-age-layer.zip | tee /tmp/no-mistakes-evidence/01KYS1KXSVPNP34KDDT44QR422/release_artifact_hashes_second.txt && diff -u /tmp/no-mistakes-evidence/01KYS1KXSVPNP34KDDT44QR422/release_artifact_hashes_first.txt /tmp/no-mistakes-evidence/01KYS1KXSVPNP34KDDT44QR422/release_artifact_hashes_second.txt`
- `python3 - <<'PY' > /tmp/no-mistakes-evidence/01KYS1KXSVPNP34KDDT44QR422/release_artifact_manifest.json ...`
- <code>`git status --short` after cleanup</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
