### PR TITLE
feat: justfile install/uninstall with SSM-backed config and S3 source copies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,5 @@ __marimo__/
 *.tfplan
 backend.tf
 terraform.tfvars
+.shared-llm/
+.build/

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -42,8 +42,11 @@ terraform init
 terraform apply
 ```
 
-By default, deployed roles read packages from `<project_prefix>-internal` and write results to
-`<project_prefix>-done`. Configure the additional bucket ARN lists when payloads use other buckets.
+By default, deployed roles read packages from `<project_prefix>-engine-internal-<account-id>`
+and write results to `<project_prefix>-engine-done-<account-id>` (account-suffixed because S3
+names are global; engine-segmented so the iac-ci foundation's `<prefix>-done-<account-id>`
+bucket is never dual-owned). Configure the additional bucket ARN lists when payloads use
+other buckets.
 
 ## CodeBuild orchestration
 

--- a/infra/00-bootstrap/main.tf
+++ b/infra/00-bootstrap/main.tf
@@ -18,6 +18,33 @@ provider "aws" {
 resource "aws_s3_bucket" "state" {
   bucket        = var.state_bucket_name
   force_destroy = false
+
+  tags = {
+    # Ownership marker read by the justfile's adoption logic. NOT atomic with
+    # creation (S3 CreateBucket carries no tags; terraform tags in a follow-up
+    # call) — the crash window is covered by the surviving LOCAL bootstrap
+    # state, and an untagged bucket without that proof aborts the install.
+    ManagedBy = "engine-00-bootstrap"
+    Purpose   = "terraform-state"
+  }
+}
+
+# Standalone installs need their own lock table; a combined install adopts the
+# iac-ci bucket AND its lock table instead (this root is never applied then).
+resource "aws_dynamodb_table" "locks" {
+  name         = var.lock_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    ManagedBy = "engine-00-bootstrap"
+    Purpose   = "terraform-state-lock"
+  }
 }
 
 resource "aws_s3_bucket_versioning" "state" {

--- a/infra/00-bootstrap/variables.tf
+++ b/infra/00-bootstrap/variables.tf
@@ -3,6 +3,11 @@ variable "state_bucket_name" {
   type        = string
 }
 
+variable "lock_table_name" {
+  description = "Name of the DynamoDB lock table for Terraform state locking"
+  type        = string
+}
+
 variable "aws_region" {
   description = "AWS region"
   type        = string

--- a/infra/02-deploy/main.tf
+++ b/infra/02-deploy/main.tf
@@ -14,11 +14,14 @@ data "aws_partition" "current" {}
 data "aws_region" "current" {}
 
 locals {
-  prefix                 = var.project_prefix
-  account_id             = data.aws_caller_identity.current.account_id
-  region                 = data.aws_region.current.region
-  internal_bucket_name   = "${local.prefix}-internal"
-  done_bucket_name       = "${local.prefix}-done"
+  prefix     = var.project_prefix
+  account_id = data.aws_caller_identity.current.account_id
+  region     = data.aws_region.current.region
+  # Account-suffixed (S3 names are global) AND engine-segmented: the iac-ci
+  # foundation stack owns "<prefix>-done-<acct>", so the engine's buckets
+  # carry an "engine" segment to avoid dual Terraform ownership of one bucket.
+  internal_bucket_name   = "${local.prefix}-engine-internal-${local.account_id}"
+  done_bucket_name       = "${local.prefix}-engine-done-${local.account_id}"
   default_lambda_memory  = var.lambda_memory
   default_lambda_timeout = var.lambda_timeout
   codebuild_compute      = var.codebuild_compute_type != "" ? var.codebuild_compute_type : "BUILD_GENERAL1_SMALL"

--- a/infra/02-deploy/terraform.tfvars.example
+++ b/infra/02-deploy/terraform.tfvars.example
@@ -5,7 +5,8 @@ engine_zip_s3_bucket  = "my-packages-bucket"
 engine_zip_s3_key     = "engine.zip"
 sops_age_layer_s3_key = "sops-age-layer.zip"
 
-# Optional access to caller-managed buckets in addition to <project_prefix>-internal/done.
+# Optional access to caller-managed buckets in addition to the default
+# <project_prefix>-engine-{internal,done}-<account-id> buckets.
 additional_package_bucket_arns = ["arn:aws:s3:::my-package-bucket"]
 additional_result_bucket_arns  = ["arn:aws:s3:::my-result-bucket"]
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,226 @@
+set positional-arguments
+
+# ref 4353245 - iac-ci remote executor consistency naming
+ENGINE_PROJECT := env_var_or_default("ENGINE_PROJECT", "iac-ci")
+ENGINE_REGION := env_var_or_default("AWS_REGION", env_var_or_default("AWS_DEFAULT_REGION", "us-east-1"))
+export AWS_REGION := ENGINE_REGION
+export SSM_CONFIG_PROJECT := "engine"
+
+# Set or read /iac-ci/install/engine/<key>. Values are passed as argv (never
+# interpolated into shell source); secrets go via stdin: just config set-stdin <key>
+config action key value="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    action="$1"; key="$2"; value="${3:-}"
+    case "$action" in
+    set) ./scripts/ssm_config.sh set "$key" "$value" ;;
+    set-stdin) ./scripts/ssm_config.sh set-stdin "$key" ;;
+    get) ./scripts/ssm_config.sh get "$key" ;;
+    *) echo "Usage: just config set|set-stdin|get <key> [value]" >&2; exit 1 ;;
+    esac
+
+# State bucket. When the shared iac-ci bucket already exists (combined install,
+# positively tagged ManagedBy=iac-ci-bootstrap) this recipe adopts it; a
+# standalone engine install creates the bucket + lock table (local state, then
+# migrated) tagged ManagedBy=engine-00-bootstrap. NOTE: S3 CreateBucket carries
+# no tags — terraform tags in a follow-up call — so a hard crash can leave an
+# engine-created bucket untagged. Recovery proof is the surviving LOCAL
+# bootstrap state; an untagged bucket WITHOUT local state is ambiguous and
+# aborts for explicit operator recovery (never silently adopted).
+bootstrap:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ACCT="$(aws sts get-caller-identity --query Account --output text)"
+    BUCKET="$(./scripts/ssm_config.sh get-or state_bucket_name "{{ENGINE_PROJECT}}-state-${ACCT}")"
+    LOCK_TABLE="{{ENGINE_PROJECT}}-tf-locks"
+    set +e; ./scripts/bucket_exists.sh "$BUCKET"; probe_rc=$?; set -e
+    [ "$probe_rc" = 0 ] || [ "$probe_rc" = 1 ] || exit "$probe_rc"
+    if [ "$probe_rc" = 0 ]; then
+        OWNER="$(./scripts/bucket_owner.sh "$BUCKET")"   # aborts on unreadable tags
+        if [ "$OWNER" = "engine-00-bootstrap" ]; then
+            # Owned by a previous engine bootstrap: re-apply against remote state.
+            ./scripts/write_tfvars.sh infra/00-bootstrap "aws_region={{ENGINE_REGION}}" "state_bucket_name=${BUCKET}" "lock_table_name=${LOCK_TABLE}"
+            ./scripts/generate_backend.sh "$BUCKET" engine-00-bootstrap "{{ENGINE_REGION}}" infra/00-bootstrap "$LOCK_TABLE"
+            terraform -chdir=infra/00-bootstrap init -reconfigure -input=false
+            terraform -chdir=infra/00-bootstrap apply -input=false -auto-approve
+        elif [ "$OWNER" = "untagged" ] && [ -s infra/00-bootstrap/terraform.tfstate ]; then
+            # Crash window recovery: the surviving LOCAL bootstrap state proves
+            # the interrupted creation is ours — resume the apply (which
+            # re-tags), then migrate as in a fresh create.
+            echo "untagged bucket ${BUCKET} with local engine bootstrap state: resuming interrupted owned creation"
+            ./scripts/write_tfvars.sh infra/00-bootstrap "aws_region={{ENGINE_REGION}}" "state_bucket_name=${BUCKET}" "lock_table_name=${LOCK_TABLE}"
+            rm -f infra/00-bootstrap/backend.tf
+            terraform -chdir=infra/00-bootstrap init -reconfigure -input=false
+            terraform -chdir=infra/00-bootstrap apply -input=false -auto-approve
+            ./scripts/generate_backend.sh "$BUCKET" engine-00-bootstrap "{{ENGINE_REGION}}" infra/00-bootstrap "$LOCK_TABLE"
+            terraform -chdir=infra/00-bootstrap init -migrate-state -force-copy -input=false
+            rm -f infra/00-bootstrap/terraform.tfstate infra/00-bootstrap/terraform.tfstate.backup
+        elif [ "$OWNER" = "untagged" ]; then
+            # Ambiguous: untagged bucket and no local proof either way. Never
+            # silently adopt — stop for explicit operator recovery.
+            echo "ERROR: bucket ${BUCKET} exists but is untagged and no local engine bootstrap state survives." >&2
+            echo "Cannot prove ownership. Recover explicitly: tag it ManagedBy=<owner> if known, or" >&2
+            echo "delete it if it was an interrupted engine creation, then re-run 'just bootstrap'." >&2
+            exit 1
+        else
+            echo "state bucket ${BUCKET} already exists (owner: ${OWNER}); adopting without owning it"
+            exit 0
+        fi
+    else
+        ./scripts/write_tfvars.sh infra/00-bootstrap "aws_region={{ENGINE_REGION}}" "state_bucket_name=${BUCKET}" "lock_table_name=${LOCK_TABLE}"
+        rm -f infra/00-bootstrap/backend.tf
+        terraform -chdir=infra/00-bootstrap init -reconfigure -input=false
+        terraform -chdir=infra/00-bootstrap apply -input=false -auto-approve
+        ./scripts/generate_backend.sh "$BUCKET" engine-00-bootstrap "{{ENGINE_REGION}}" infra/00-bootstrap "$LOCK_TABLE"
+        terraform -chdir=infra/00-bootstrap init -migrate-state -force-copy -input=false
+        rm -f infra/00-bootstrap/terraform.tfstate infra/00-bootstrap/terraform.tfstate.backup
+    fi
+    ./scripts/upload_source.sh "$BUCKET" engine-00-bootstrap . infra/00-bootstrap
+
+bootstrap-destroy:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ACCT="$(aws sts get-caller-identity --query Account --output text)"
+    BUCKET="$(./scripts/ssm_config.sh get-or state_bucket_name "{{ENGINE_PROJECT}}-state-${ACCT}")"
+    LOCK_TABLE="{{ENGINE_PROJECT}}-tf-locks"
+    set +e; ./scripts/bucket_exists.sh "$BUCKET"; probe_rc=$?; set -e
+    [ "$probe_rc" = 0 ] || [ "$probe_rc" = 1 ] || exit "$probe_rc"
+    set +e; ./scripts/table_exists.sh "$LOCK_TABLE"; table_rc=$?; set -e
+    [ "$table_rc" = 0 ] || [ "$table_rc" = 1 ] || exit "$table_rc"
+    ./scripts/write_tfvars.sh infra/00-bootstrap "aws_region={{ENGINE_REGION}}" "state_bucket_name=${BUCKET}" "lock_table_name=${LOCK_TABLE}"
+    if [ "$probe_rc" = 1 ]; then
+        # Bucket gone — but a partial standalone bootstrap may have left local
+        # state and/or the lock table. Do not strand them.
+        if [ -s infra/00-bootstrap/terraform.tfstate ]; then
+            echo "no bucket but local engine bootstrap state survives: destroying tracked resources from local state"
+            rm -f infra/00-bootstrap/backend.tf
+            terraform -chdir=infra/00-bootstrap init -reconfigure -input=false
+            terraform -chdir=infra/00-bootstrap destroy -input=false -auto-approve
+            rm -f infra/00-bootstrap/terraform.tfstate infra/00-bootstrap/terraform.tfstate.backup
+        elif [ "$table_rc" = 0 ]; then
+            TABLE_OWNER="$(aws dynamodb list-tags-of-resource --resource-arn "arn:aws:dynamodb:{{ENGINE_REGION}}:${ACCT}:table/${LOCK_TABLE}" --query "Tags[?Key=='ManagedBy'].Value" --output text)"
+            if [ "$TABLE_OWNER" = "engine-00-bootstrap" ]; then
+                echo "stranded engine-owned lock table ${LOCK_TABLE} found without state; deleting directly"
+                aws dynamodb delete-table --table-name "$LOCK_TABLE" >/dev/null
+                aws dynamodb wait table-not-exists --table-name "$LOCK_TABLE"
+            else
+                echo "lock table ${LOCK_TABLE} is not engine-owned (owner: ${TABLE_OWNER:-untagged}); leaving it"
+                LEFT_FOREIGN_TABLE=1
+            fi
+        else
+            echo "state bucket ${BUCKET} not found; nothing to destroy"
+        fi
+        # Postconditions for the owned/standalone paths we just handled: the
+        # bucket must be gone, and the lock table must be gone too unless we
+        # explicitly left a foreign-owned table in place.
+        set +e; ./scripts/bucket_exists.sh "$BUCKET"; post_rc=$?; set -e
+        [ "$post_rc" = 1 ] || { echo "ERROR: ${BUCKET} still exists or is unverifiable (rc=${post_rc})" >&2; exit 1; }
+        if [ "${LEFT_FOREIGN_TABLE:-0}" != 1 ]; then
+            set +e; ./scripts/table_exists.sh "$LOCK_TABLE"; post_table_rc=$?; set -e
+            [ "$post_table_rc" = 1 ] || { echo "ERROR: ${LOCK_TABLE} still exists or is unverifiable (rc=${post_table_rc})" >&2; exit 1; }
+        fi
+        exit 0
+    fi
+    OWNER="$(./scripts/bucket_owner.sh "$BUCKET")"   # aborts on unreadable tags
+    if [ "$OWNER" = "engine-00-bootstrap" ]; then
+        # Normal owned teardown: state is remote — migrate it out, empty, destroy.
+        ./scripts/generate_backend.sh "$BUCKET" engine-00-bootstrap "{{ENGINE_REGION}}" infra/00-bootstrap "$LOCK_TABLE"
+        terraform -chdir=infra/00-bootstrap init -reconfigure -input=false
+        rm -f infra/00-bootstrap/backend.tf
+        terraform -chdir=infra/00-bootstrap init -migrate-state -force-copy -input=false
+        ./scripts/empty_bucket.sh "$BUCKET"
+        terraform -chdir=infra/00-bootstrap destroy -input=false -auto-approve
+        rm -f infra/00-bootstrap/terraform.tfstate infra/00-bootstrap/terraform.tfstate.backup
+    elif [ "$OWNER" = "untagged" ] && [ -s infra/00-bootstrap/terraform.tfstate ]; then
+        # Interrupted owned creation: state never migrated — it is still LOCAL.
+        # Do NOT migrate from the (empty) remote key; destroy from local state.
+        echo "untagged bucket ${BUCKET} with local engine bootstrap state: destroying interrupted owned creation from local state"
+        rm -f infra/00-bootstrap/backend.tf
+        terraform -chdir=infra/00-bootstrap init -reconfigure -input=false
+        ./scripts/empty_bucket.sh "$BUCKET"
+        terraform -chdir=infra/00-bootstrap destroy -input=false -auto-approve
+        rm -f infra/00-bootstrap/terraform.tfstate infra/00-bootstrap/terraform.tfstate.backup
+    elif [ "$OWNER" = "untagged" ]; then
+        echo "ERROR: bucket ${BUCKET} is untagged and no local engine bootstrap state survives." >&2
+        echo "Cannot prove ownership — refusing to skip OR destroy. Recover explicitly (tag or delete it)." >&2
+        exit 1
+    else
+        echo "state bucket ${BUCKET} is not owned by the engine install (owner: ${OWNER}); skipping"
+        exit 0
+    fi
+    # Postconditions: an owned destroy must leave neither bucket nor table.
+    set +e; ./scripts/bucket_exists.sh "$BUCKET"; post_bucket_rc=$?; set -e
+    [ "$post_bucket_rc" = 1 ] || { echo "ERROR: ${BUCKET} still exists or is unverifiable (rc=${post_bucket_rc})" >&2; exit 1; }
+    set +e; ./scripts/table_exists.sh "$LOCK_TABLE"; post_table_rc=$?; set -e
+    [ "$post_table_rc" = 1 ] || { echo "ERROR: ${LOCK_TABLE} still exists or is unverifiable (rc=${post_table_rc})" >&2; exit 1; }
+
+# Build engine.zip + sops-age-layer.zip and upload them to the state bucket.
+build:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ACCT="$(aws sts get-caller-identity --query Account --output text)"
+    BUCKET="$(./scripts/ssm_config.sh get-or state_bucket_name "{{ENGINE_PROJECT}}-state-${ACCT}")"
+    ./scripts/build-release-zip.sh
+    aws s3 cp dist/engine.zip "s3://${BUCKET}/engine/artifacts/engine.zip" --sse AES256 --only-show-errors
+    aws s3 cp dist/sops-age-layer.zip "s3://${BUCKET}/engine/artifacts/sops-age-layer.zip" --sse AES256 --only-show-errors
+    echo "uploaded engine artifacts to s3://${BUCKET}/engine/artifacts/"
+
+deploy:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ACCT="$(aws sts get-caller-identity --query Account --output text)"
+    BUCKET="$(./scripts/ssm_config.sh get-or state_bucket_name "{{ENGINE_PROJECT}}-state-${ACCT}")"
+    PREFIX="$(./scripts/ssm_config.sh get-or project_prefix "{{ENGINE_PROJECT}}")"
+    KMS_KEY_ARN="$(aws kms describe-key --key-id "alias/{{ENGINE_PROJECT}}-foundation" --query KeyMetadata.Arn --output text)"
+    ./scripts/write_tfvars.sh infra/02-deploy \
+        "project_prefix=${PREFIX}" \
+        "kms_key_arn=${KMS_KEY_ARN}" \
+        "engine_zip_s3_bucket=${BUCKET}" \
+        "engine_zip_s3_key=engine/artifacts/engine.zip" \
+        "sops_age_layer_s3_key=engine/artifacts/sops-age-layer.zip" \
+        "additional_package_bucket_arns=[\"arn:aws:s3:::{{ENGINE_PROJECT}}-package-${ACCT}\",\"arn:aws:s3:::{{ENGINE_PROJECT}}-tmp-${ACCT}\"]" \
+        "additional_result_bucket_arns=[\"arn:aws:s3:::{{ENGINE_PROJECT}}-done-${ACCT}\",\"arn:aws:s3:::{{ENGINE_PROJECT}}-tmp-${ACCT}\"]"
+    ./scripts/generate_backend.sh "$BUCKET" engine-02-deploy "{{ENGINE_REGION}}" infra/02-deploy "{{ENGINE_PROJECT}}-tf-locks"
+    terraform -chdir=infra/02-deploy init -reconfigure -input=false
+    terraform -chdir=infra/02-deploy apply -input=false -auto-approve
+    ./scripts/upload_source.sh "$BUCKET" engine-02-deploy . infra/02-deploy
+
+deploy-destroy:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ACCT="$(aws sts get-caller-identity --query Account --output text)"
+    BUCKET="$(./scripts/ssm_config.sh get-or state_bucket_name "{{ENGINE_PROJECT}}-state-${ACCT}")"
+    set +e; ./scripts/bucket_exists.sh "$BUCKET"; probe_rc=$?; set -e
+    [ "$probe_rc" = 0 ] || [ "$probe_rc" = 1 ] || exit "$probe_rc"
+    if [ "$probe_rc" = 1 ]; then
+        echo "state bucket ${BUCKET} not found; nothing to destroy"
+        exit 0
+    fi
+    PREFIX="$(./scripts/ssm_config.sh get-or project_prefix "{{ENGINE_PROJECT}}")"
+    KMS_KEY_ARN="$(aws kms describe-key --key-id "alias/{{ENGINE_PROJECT}}-foundation" --query KeyMetadata.Arn --output text)"
+    ./scripts/write_tfvars.sh infra/02-deploy \
+        "project_prefix=${PREFIX}" \
+        "kms_key_arn=${KMS_KEY_ARN}" \
+        "engine_zip_s3_bucket=${BUCKET}" \
+        "engine_zip_s3_key=engine/artifacts/engine.zip" \
+        "sops_age_layer_s3_key=engine/artifacts/sops-age-layer.zip"
+    ./scripts/generate_backend.sh "$BUCKET" engine-02-deploy "{{ENGINE_REGION}}" infra/02-deploy "{{ENGINE_PROJECT}}-tf-locks"
+    terraform -chdir=infra/02-deploy init -reconfigure -input=false
+    terraform -chdir=infra/02-deploy destroy -input=false -auto-approve
+    # Reverse of `build`: purge uploaded artifacts even when the bucket is
+    # shared (adopted) and therefore survives this uninstall.
+    ./scripts/empty_bucket.sh "$BUCKET" "engine/artifacts/"
+
+# Full engine install: bootstrap -> build -> deploy
+install:
+    @just bootstrap
+    @just build
+    @just deploy
+
+# Exact reverse of install. deploy-destroy purges build artifacts explicitly
+# (the state bucket may be shared/adopted and survive); a standalone install
+# also removes its own SSM namespace.
+uninstall:
+    @just deploy-destroy
+    @just bootstrap-destroy
+    ./scripts/ssm_config.sh delete-all

--- a/scripts/bucket_exists.sh
+++ b/scripts/bucket_exists.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fail-loud bucket existence probe.
+#   exit 0  -> bucket exists (and we can reach it)
+#   exit 1  -> bucket genuinely does not exist (404)
+#   exit 2  -> ANY other failure (expired STS, AccessDenied, network, 301) —
+#              callers must abort, never treat this as "missing".
+#
+# Usage: bucket_exists.sh <bucket>
+
+BUCKET="${1:?Usage: bucket_exists.sh <bucket>}"
+
+err_file="$(mktemp)"
+trap 'rm -f "$err_file"' EXIT
+
+if aws s3api head-bucket --bucket "$BUCKET" 2>"$err_file"; then
+  exit 0
+fi
+if grep -Eq '404|Not Found|NoSuchBucket' "$err_file"; then
+  exit 1
+fi
+echo "ERROR: head-bucket ${BUCKET} failed (NOT a missing bucket):" >&2
+cat "$err_file" >&2
+exit 2

--- a/scripts/bucket_owner.sh
+++ b/scripts/bucket_owner.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fail-loud bucket ownership probe: prints the bucket's ManagedBy tag value,
+# or "untagged" when the bucket verifiably has no tag set. ANY other failure
+# (expired STS, AccessDenied, network) aborts — an unreadable tag must never
+# be interpreted as "not ours".
+#
+# Usage: bucket_owner.sh <bucket>
+
+BUCKET="${1:?Usage: bucket_owner.sh <bucket>}"
+
+err_file="$(mktemp)"
+trap 'rm -f "$err_file"' EXIT
+
+if owner="$(aws s3api get-bucket-tagging --bucket "$BUCKET" \
+  --query "TagSet[?Key=='ManagedBy'].Value" --output text 2>"$err_file")"; then
+  if [ -z "$owner" ] || [ "$owner" = "None" ]; then
+    echo "untagged"
+  else
+    echo "$owner"
+  fi
+  exit 0
+fi
+if grep -q 'NoSuchTagSet' "$err_file"; then
+  echo "untagged"
+  exit 0
+fi
+echo "ERROR: get-bucket-tagging ${BUCKET} failed (NOT an untagged bucket):" >&2
+cat "$err_file" >&2
+exit 2

--- a/scripts/build-release-zip.sh
+++ b/scripts/build-release-zip.sh
@@ -137,5 +137,5 @@ docker run --rm \
 
 printf '%s\n' "=== Release artifacts ==="
 for artifact in "$DIST_DIR/engine.zip" "$DIST_DIR/sops-age-layer.zip"; do
-	printf '  %s (%s bytes)\n' "$artifact" "$(stat -c%s "$artifact")"
+	printf '  %s (%s bytes)\n' "$artifact" "$(wc -c <"$artifact" | tr -d ' ')"
 done

--- a/scripts/empty_bucket.sh
+++ b/scripts/empty_bucket.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Permanently delete every object version and delete marker in a bucket (or
+# under a prefix) so the bucket can be removed / the prefix truly reversed.
+# No-ops (successfully) ONLY on a genuine 404; any other head-bucket failure
+# (expired STS, AccessDenied) aborts.
+#
+# Usage: empty_bucket.sh <bucket> [prefix]
+
+BUCKET="${1:?Usage: empty_bucket.sh <bucket> [prefix]}"
+PREFIX="${2:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Capture the probe's real exit status (a bare `if !` would lose it: $? inside
+# the else branch is the status of `!`, i.e. 0).
+set +e
+"$SCRIPT_DIR/bucket_exists.sh" "$BUCKET"
+probe_rc=$?
+set -e
+case "$probe_rc" in
+0) : ;;
+1)
+  echo "bucket ${BUCKET} does not exist; nothing to empty"
+  exit 0
+  ;;
+*)
+  echo "ERROR: cannot determine whether ${BUCKET} exists (probe rc=${probe_rc}); refusing to continue" >&2
+  exit "$probe_rc"
+  ;;
+esac
+
+PREFIX_ARGS=()
+[ -n "$PREFIX" ] && PREFIX_ARGS=(--prefix "$PREFIX")
+
+while :; do
+  versions="$(aws s3api list-object-versions --bucket "$BUCKET" ${PREFIX_ARGS[@]+"${PREFIX_ARGS[@]}"} --max-items 500 \
+    --query '{Objects: [Versions[].{Key:Key,VersionId:VersionId}, DeleteMarkers[].{Key:Key,VersionId:VersionId}][] | [0:500]}' \
+    --output json)"
+  count="$(printf '%s' "$versions" | jq '.Objects | length')"
+  if [ "$count" -eq 0 ]; then
+    break
+  fi
+  printf '%s' "$versions" | jq '{Objects: .Objects, Quiet: true}' >/tmp/empty_bucket_batch.$$.json
+  aws s3api delete-objects --bucket "$BUCKET" --delete "file:///tmp/empty_bucket_batch.$$.json" >/dev/null
+  rm -f "/tmp/empty_bucket_batch.$$.json"
+  echo "deleted ${count} versions from ${BUCKET}"
+done
+
+echo "emptied ${BUCKET}${PREFIX:+/${PREFIX}}"

--- a/scripts/generate_backend.sh
+++ b/scripts/generate_backend.sh
@@ -1,23 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ $# -ne 3 ]; then
-  echo "Usage: $0 <bucket_name> <stage_key> <region>" >&2
-  exit 1
+# Generates a backend.tf file in the specified directory for S3 remote state.
+#
+# Usage: generate_backend.sh <bucket_name> <state_key> <region> <target_dir> [lock_table]
+#
+# Example:
+#   ./scripts/generate_backend.sh iac-ci-state-099623381343 deploy us-east-1 infra/deploy/ iac-ci-tf-locks
+
+BUCKET_NAME="${1:?Usage: generate_backend.sh <bucket_name> <state_key> <region> <target_dir> [lock_table]}"
+STATE_KEY="${2:?Usage: generate_backend.sh <bucket_name> <state_key> <region> <target_dir> [lock_table]}"
+REGION="${3:?Usage: generate_backend.sh <bucket_name> <state_key> <region> <target_dir> [lock_table]}"
+TARGET_DIR="${4:?Usage: generate_backend.sh <bucket_name> <state_key> <region> <target_dir> [lock_table]}"
+LOCK_TABLE="${5:-}"
+
+LOCK_LINE=""
+if [ -n "$LOCK_TABLE" ]; then
+  LOCK_LINE="    dynamodb_table = \"${LOCK_TABLE}\""
 fi
 
-BUCKET_NAME="$1"
-STAGE_KEY="$2"
-REGION="$3"
-
-cat > backend.tf <<EOF
+cat >"${TARGET_DIR}/backend.tf" <<EOF
 terraform {
   backend "s3" {
     bucket = "${BUCKET_NAME}"
-    key    = "${STAGE_KEY}/terraform.tfstate"
+    key    = "${STATE_KEY}/terraform.tfstate"
     region = "${REGION}"
+${LOCK_LINE}
   }
 }
 EOF
 
-echo "Generated backend.tf (bucket=${BUCKET_NAME}, key=${STAGE_KEY}/terraform.tfstate, region=${REGION})"
+echo "Generated ${TARGET_DIR}/backend.tf (bucket=${BUCKET_NAME}, key=${STATE_KEY}/terraform.tfstate)"

--- a/scripts/ssm_config.sh
+++ b/scripts/ssm_config.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install-time configuration in SSM Parameter Store (SecureString).
+# All config lives under /iac-ci/install/<project>/<key>.
+#
+# Usage:
+#   ssm_config.sh set <key> <value>         # non-secret values
+#   ssm_config.sh set-stdin <key>           # secret values (read from stdin)
+#   ssm_config.sh get <key>                 # fails if unset
+#   ssm_config.sh get-or <key> <default>    # default ONLY on ParameterNotFound
+#   ssm_config.sh delete-all                # removes the whole namespace
+#
+# Project namespace defaults to "engine"; override with SSM_CONFIG_PROJECT.
+#
+# Fail-loud contract: only a genuine ParameterNotFound falls back to the
+# default. Expired credentials, AccessDenied, throttling, and network errors
+# always abort — silently defaulting on those could flip ownership or naming
+# decisions mid-install.
+
+PROJECT="${SSM_CONFIG_PROJECT:-engine}"
+PREFIX="/iac-ci/install/${PROJECT}"
+
+usage() {
+  grep '^#   ' "$0" | sed 's/^#   //' >&2
+  exit 1
+}
+
+put_param() { # <key> <value>
+  aws ssm put-parameter --name "${PREFIX}/$1" --value "$2" \
+    --type SecureString --overwrite >/dev/null
+  echo "set ${PREFIX}/$1"
+}
+
+cmd="${1:-}"
+case "$cmd" in
+set)
+  key="${2:?set requires <key> <value>}"
+  value="${3:?set requires <key> <value>}"
+  put_param "$key" "$value"
+  ;;
+set-stdin)
+  key="${2:?set-stdin requires <key>}"
+  value="$(cat)"
+  [ -n "$value" ] || {
+    echo "ERROR: empty value on stdin" >&2
+    exit 1
+  }
+  put_param "$key" "$value"
+  ;;
+get)
+  key="${2:?get requires <key>}"
+  aws ssm get-parameter --name "${PREFIX}/${key}" --with-decryption \
+    --query 'Parameter.Value' --output text
+  ;;
+get-or)
+  key="${2:?get-or requires <key> <default>}"
+  default="${3?get-or requires <key> <default>}"
+  err_file="$(mktemp)"
+  trap 'rm -f "$err_file"' EXIT
+  if value="$(aws ssm get-parameter --name "${PREFIX}/${key}" --with-decryption \
+    --query 'Parameter.Value' --output text 2>"$err_file")"; then
+    echo "$value"
+  elif grep -q 'ParameterNotFound' "$err_file"; then
+    echo "$default"
+  else
+    echo "ERROR: SSM get-parameter ${PREFIX}/${key} failed (NOT a missing parameter):" >&2
+    cat "$err_file" >&2
+    exit 1
+  fi
+  ;;
+delete-all)
+  names="$(aws ssm get-parameters-by-path --path "$PREFIX" --recursive \
+    --query 'Parameters[].Name' --output text)"
+  if [ -z "$names" ] || [ "$names" = "None" ]; then
+    echo "no parameters under ${PREFIX}"
+    exit 0
+  fi
+  for name in $names; do
+    aws ssm delete-parameter --name "$name"
+    echo "deleted $name"
+  done
+  ;;
+*)
+  usage
+  ;;
+esac

--- a/scripts/table_exists.sh
+++ b/scripts/table_exists.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fail-loud DynamoDB table existence probe.
+#   exit 0 -> table exists
+#   exit 1 -> table genuinely does not exist (ResourceNotFoundException)
+#   exit 2 -> ANY other failure (expired STS, AccessDenied, throttling) —
+#             callers must abort, never treat this as "missing".
+#
+# Usage: table_exists.sh <table>
+
+TABLE="${1:?Usage: table_exists.sh <table>}"
+
+err_file="$(mktemp)"
+trap 'rm -f "$err_file"' EXIT
+
+if aws dynamodb describe-table --table-name "$TABLE" >/dev/null 2>"$err_file"; then
+  exit 0
+fi
+if grep -q 'ResourceNotFoundException' "$err_file"; then
+  exit 1
+fi
+echo "ERROR: describe-table ${TABLE} failed (NOT a missing table):" >&2
+cat "$err_file" >&2
+exit 2

--- a/scripts/upload_source.sh
+++ b/scripts/upload_source.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Upload a COMPLETE copy of the applied Terraform source for one root to the
+# state bucket: s3://<bucket>/source/<root_name>/ — single authoritative copy,
+# overwritten on every apply (bucket versioning provides history). SSE-S3.
+#
+# Also writes manifest.json: root, timestamp, terraform version, and variable
+# NAMES only (never values). terraform.tfvars itself is NEVER uploaded.
+#
+# Usage: upload_source.sh <state_bucket> <root_name> <repo_root> <rel_dir> [rel_dir ...]
+#   rel_dir paths are relative to <repo_root>; the first is the root itself,
+#   extras are shared module directories the root references.
+
+BUCKET="${1:?Usage: upload_source.sh <state_bucket> <root_name> <repo_root> <rel_dir>...}"
+ROOT_NAME="${2:?root_name required}"
+REPO_ROOT="${3:?repo_root required}"
+shift 3
+[ $# -ge 1 ] || {
+  echo "ERROR: at least one rel_dir required" >&2
+  exit 1
+}
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+for rel in "$@"; do
+  src="${REPO_ROOT}/${rel}"
+  [ -d "$src" ] || {
+    echo "ERROR: not a directory: $src" >&2
+    exit 1
+  }
+  mkdir -p "$STAGE/$rel"
+  # STRICT ALLOWLIST: only Terraform source and the provider lock file are
+  # ever uploaded. Variable VALUES in any form (*.tfvars, *.tfvars.json,
+  # *.auto.tfvars*), state, plans, overrides, and arbitrary untracked files
+  # must never reach the (versioned, forever-retained) source record.
+  (cd "$src" && find . \
+    -name .terraform -prune -o \
+    -type f \
+    \( -name '*.tf' -o -name '*.tf.json' -o -name '.terraform.lock.hcl' \) \
+    ! -name '*.tfvars' ! -name '*.tfvars.json' \
+    ! -name '*_override.tf' ! -name '*_override.tf.json' ! -name 'override.tf' ! -name 'override.tf.json' \
+    ! -name 'backend.tf' \
+    -print | while IFS= read -r f; do
+    mkdir -p "$STAGE/$rel/$(dirname "$f")"
+    cp "$f" "$STAGE/$rel/$f"
+  done)
+  # Regression guard: fail hard if anything value-bearing slipped into the stage.
+  if find "$STAGE/$rel" -type f \( -name '*tfvars*' -o -name '*.tfstate*' -o -name '*.tfplan' \) | grep -q .; then
+    echo "ERROR: variable-value or state file staged for upload — aborting" >&2
+    exit 1
+  fi
+done
+
+# Manifest: variable names come from the root's terraform.tfvars keys.
+ROOT_REL="$1"
+TFVARS="${REPO_ROOT}/${ROOT_REL}/terraform.tfvars"
+VAR_NAMES="[]"
+if [ -f "$TFVARS" ]; then
+  VAR_NAMES="$(sed -n 's/^\([a-zA-Z0-9_-]*\)[[:space:]]*=.*/\1/p' "$TFVARS" | jq -R . | jq -sc .)"
+fi
+TF_VERSION="$(terraform version -json | jq -r .terraform_version)"
+jq -n \
+  --arg root "$ROOT_NAME" \
+  --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg terraform_version "$TF_VERSION" \
+  --argjson variable_names "$VAR_NAMES" \
+  '{root: $root, timestamp: $timestamp, terraform_version: $terraform_version, variable_names: $variable_names}' \
+  >"$STAGE/manifest.json"
+
+aws s3 sync "$STAGE" "s3://${BUCKET}/source/${ROOT_NAME}/" --delete --sse AES256 --only-show-errors
+echo "uploaded source copy: s3://${BUCKET}/source/${ROOT_NAME}/"

--- a/scripts/write_tfvars.sh
+++ b/scripts/write_tfvars.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Write terraform.tfvars into a terraform root from key=value arguments.
+# Values that look like JSON arrays/objects, numbers, or booleans are written
+# raw; everything else is quoted. The file is gitignored — it may hold values
+# read from SSM and must never be committed or uploaded.
+#
+# Usage: write_tfvars.sh <root_dir> [key=value ...]
+
+ROOT_DIR="${1:?Usage: write_tfvars.sh <root_dir> [key=value ...]}"
+shift
+
+[ -d "$ROOT_DIR" ] || {
+  echo "ERROR: not a directory: $ROOT_DIR" >&2
+  exit 1
+}
+
+OUT="${ROOT_DIR}/terraform.tfvars"
+: >"$OUT"
+
+for pair in "$@"; do
+  key="${pair%%=*}"
+  value="${pair#*=}"
+  if [ -z "$key" ] || [ "$key" = "$pair" ]; then
+    echo "ERROR: argument is not key=value: $pair" >&2
+    exit 1
+  fi
+  case "$value" in
+  \[* | \{* | true | false)
+    printf '%s = %s\n' "$key" "$value" >>"$OUT"
+    ;;
+  *)
+    if printf '%s' "$value" | grep -Eq '^-?[0-9]+(\.[0-9]+)?$'; then
+      printf '%s = %s\n' "$key" "$value" >>"$OUT"
+    else
+      printf '%s = "%s"\n' "$key" "$value" >>"$OUT"
+    fi
+    ;;
+  esac
+done
+
+echo "wrote ${OUT} ($# variables)"

--- a/tests/install/test_bootstrap_destroy_branches.sh
+++ b/tests/install/test_bootstrap_destroy_branches.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Mocked branch tests for `just bootstrap-destroy` recovery paths. No AWS, no
+# terraform: fake `aws` and `terraform` binaries on PATH simulate the account.
+# State lives in $MOCK_STATE so delete-table takes effect for later probes.
+#
+# Scenarios:
+#   A) bucket missing + engine-owned lock table survives, no local state
+#      -> table deleted directly, postconditions pass (exit 0)
+#   B) bucket missing + engine-owned lock table that CANNOT be deleted
+#      -> table postcondition must FAIL (nonzero) — surviving table is an error
+#   C) bucket missing + table probe indeterminate (expired STS) -> abort (rc 2)
+#   D) bucket missing + FOREIGN-owned table -> left in place, exit 0
+#
+# Run: tests/install/test_bootstrap_destroy_branches.sh
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+MOCK_DIR="$(mktemp -d)"
+export MOCK_STATE="$MOCK_DIR/state"
+trap 'rm -rf "$MOCK_DIR"' EXIT
+
+cat >"$MOCK_DIR/aws" <<'MOCK'
+#!/usr/bin/env bash
+# Behavior driven by env: MOCK_TABLE=present|absent|expired|foreign|undeletable
+case "$*" in
+*"sts get-caller-identity"*) echo "123456789012"; exit 0 ;;
+*"ssm get-parameter"*) echo "An error occurred (ParameterNotFound) when calling the GetParameter operation" >&2; exit 254 ;;
+*"s3api head-bucket"*) echo "An error occurred (404) when calling the HeadBucket operation: Not Found" >&2; exit 254 ;;
+*"dynamodb describe-table"*)
+  if [ -f "$MOCK_STATE/table-deleted" ] || [ "${MOCK_TABLE}" = absent ]; then
+    echo "An error occurred (ResourceNotFoundException) when calling the DescribeTable operation" >&2; exit 254
+  elif [ "${MOCK_TABLE}" = expired ]; then
+    echo "An error occurred (ExpiredToken) when calling the DescribeTable operation" >&2; exit 254
+  fi
+  exit 0 ;;
+*"dynamodb list-tags-of-resource"*)
+  if [ "${MOCK_TABLE}" = foreign ]; then echo "someone-else"; else echo "engine-00-bootstrap"; fi
+  exit 0 ;;
+*"dynamodb delete-table"*)
+  if [ "${MOCK_TABLE}" = undeletable ]; then exit 0; fi   # pretends to work, table survives
+  mkdir -p "$MOCK_STATE"; touch "$MOCK_STATE/table-deleted"; exit 0 ;;
+*"dynamodb wait table-not-exists"*) exit 0 ;;
+*) exit 0 ;;
+esac
+MOCK
+cat >"$MOCK_DIR/terraform" <<'MOCK'
+#!/usr/bin/env bash
+exit 0
+MOCK
+chmod +x "$MOCK_DIR/aws" "$MOCK_DIR/terraform"
+export PATH="$MOCK_DIR:$PATH"
+
+FAILURES=0
+run_case() { # <desc> <want_rc> <MOCK_TABLE value>
+  local desc="$1" want="$2" table="$3" got=0
+  rm -rf "$MOCK_STATE"
+  rm -f "$REPO/infra/00-bootstrap/terraform.tfstate"
+  MOCK_TABLE="$table" just --justfile "$REPO/justfile" --working-directory "$REPO" bootstrap-destroy >/dev/null 2>&1 || got=$?
+  if [ "$got" = "$want" ]; then
+    echo "PASS ${desc} (rc=${got})"
+  else
+    echo "FAIL ${desc}: want rc=${want}, got rc=${got}"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+run_case "A: stranded engine-owned table deleted, postconditions pass" 0 present
+run_case "B: surviving table after delete must fail postcondition" 1 undeletable
+run_case "C: indeterminate table probe aborts" 2 expired
+run_case "D: foreign-owned table left in place, success" 0 foreign
+
+if [ "$FAILURES" -gt 0 ]; then
+  echo "bootstrap-destroy branch tests: ${FAILURES} failure(s)"
+  exit 1
+fi
+echo "bootstrap-destroy branch tests: all passed"

--- a/tests/smoke/test_deploy.sh
+++ b/tests/smoke/test_deploy.sh
@@ -20,8 +20,9 @@ for var in PREFIX AWS_REGION; do
 	fi
 done
 
-INTERNAL_BUCKET="${PREFIX}-internal"
-DONE_BUCKET="${PREFIX}-done"
+ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+INTERNAL_BUCKET="${PREFIX}-engine-internal-${ACCOUNT_ID}"
+DONE_BUCKET="${PREFIX}-engine-done-${ACCOUNT_ID}"
 
 for SUFFIX in init-job worker finalizer; do
 	FUNC="${PREFIX}-${SUFFIX}"


### PR DESCRIPTION
Companion to config0-hub/iac-ci#6 (single commit). Adds the engine's install/uninstall justfile: SSM-backed config → gitignored tfvars → apply → complete source copy to the state bucket; standalone lock table; tag-based crash-safe bucket ownership with ambiguity aborts; artifact purge on destroy; account-suffixed engine-segmented bucket names; mocked bootstrap-destroy branch tests. Verified in the full iac-ci install/uninstall journey in a real test account.