### PR TITLE
CodeBuild worker: privileged mode + real runtime bounds

### DIFF
--- a/infra/02-deploy/codebuild.tf
+++ b/infra/02-deploy/codebuild.tf
@@ -2,10 +2,12 @@ resource "aws_codebuild_project" "worker" {
   name         = "${local.prefix}-worker"
   service_role = aws_iam_role.codebuild.arn
 
-  # Hard runtime bound: CodeBuild stops the build after 15 minutes, matching
-  # the platform's 900-second worker-watch ceiling - a build the watch has
-  # abandoned cannot keep running and race a requeued execution.
-  build_timeout = 15
+  # Hard runtime bound: the platform watch gives 900s from FIRE = 600s build
+  # + 300s queue/provisioning, and CodeBuild's own clock starts AFTER
+  # provisioning - a 15-minute clock could outlive the watch and race a
+  # requeue. 10 minutes (600s) matches the authored caps exactly, so even a
+  # provisioning-delayed build dies inside the watch window.
+  build_timeout = 10
 
   artifacts {
     type = "NO_ARTIFACTS"

--- a/infra/02-deploy/codebuild.tf
+++ b/infra/02-deploy/codebuild.tf
@@ -2,6 +2,11 @@ resource "aws_codebuild_project" "worker" {
   name         = "${local.prefix}-worker"
   service_role = aws_iam_role.codebuild.arn
 
+  # Hard runtime bound: CodeBuild stops the build after 15 minutes, matching
+  # the platform's 900-second worker-watch ceiling - a build the watch has
+  # abandoned cannot keep running and race a requeued execution.
+  build_timeout = 15
+
   artifacts {
     type = "NO_ARTIFACTS"
   }

--- a/infra/02-deploy/codebuild.tf
+++ b/infra/02-deploy/codebuild.tf
@@ -2,12 +2,22 @@ resource "aws_codebuild_project" "worker" {
   name         = "${local.prefix}-worker"
   service_role = aws_iam_role.codebuild.arn
 
-  # Hard runtime bound: the platform watch gives 900s from FIRE = 600s build
-  # + 300s queue/provisioning, and CodeBuild's own clock starts AFTER
-  # provisioning - a 15-minute clock could outlive the watch and race a
-  # requeue. 10 minutes (600s) matches the authored caps exactly, so even a
-  # provisioning-delayed build dies inside the watch window.
-  build_timeout = 10
+  # Two clocks bound the build against the platform's 900s watch from FIRE:
+  #   queued_timeout (5 min = 300s) + build_timeout (10 min = 600s) = 900s.
+  # Verified AWS semantics (CodeBuild API reference, Project type):
+  #   - queuedTimeoutInMinutes: "The number of minutes a build is allowed to
+  #     be queued before it times out." Covers the QUEUED phase only.
+  #     Minimum allowed value is 5, so 300s is the tightest enforceable bound.
+  #   - timeoutInMinutes: "How long, in minutes ... for AWS CodeBuild to wait
+  #     before timing out any related build that did not get marked as
+  #     completed." This is the post-queue build clock.
+  # HONEST GAP: AWS does not explicitly document which clock the PROVISIONING
+  # phase counts against. If provisioning falls outside both clocks, the
+  # 300 + 600 arithmetic is not a proof; the Step Functions TimeoutSeconds
+  # (step_functions.tf) stays the wall-clock backstop that bounds the whole
+  # startBuild.sync task, provisioning included.
+  build_timeout  = 10
+  queued_timeout = 5
 
   artifacts {
     type = "NO_ARTIFACTS"

--- a/infra/02-deploy/codebuild.tf
+++ b/infra/02-deploy/codebuild.tf
@@ -10,7 +10,7 @@ resource "aws_codebuild_project" "worker" {
     compute_type                = local.codebuild_compute
     image                       = "aws/codebuild/standard:7.0"
     type                        = "LINUX_CONTAINER"
-    privileged_mode             = false
+    privileged_mode             = true
     image_pull_credentials_type = "CODEBUILD"
 
     environment_variable {

--- a/infra/02-deploy/step_functions.tf
+++ b/infra/02-deploy/step_functions.tf
@@ -61,9 +61,12 @@ resource "aws_sfn_state_machine" "codebuild" {
       RunCodeBuild = {
         Type     = "Task"
         Resource = "arn:${data.aws_partition.current.partition}:states:::codebuild:startBuild.sync"
-        # build_timeout (10 min = 600s) + 300s queue/provisioning + margin: a stuck
-        # startBuild.sync times the state out into the Catch -> FinalizeResult
-        # path instead of hanging the workflow forever.
+        # queued_timeout (5 min = 300s) + build_timeout (10 min = 600s) + 300s
+        # margin: this is the WALL-CLOCK backstop over the whole
+        # startBuild.sync task - it also covers the PROVISIONING phase, which
+        # AWS does not explicitly assign to either CodeBuild clock
+        # (codebuild.tf). A stuck build times the state out into the
+        # Catch -> FinalizeResult path instead of hanging the workflow forever.
         TimeoutSeconds = 1200
         Parameters = {
           ProjectName = aws_codebuild_project.worker.name

--- a/infra/02-deploy/step_functions.tf
+++ b/infra/02-deploy/step_functions.tf
@@ -61,7 +61,7 @@ resource "aws_sfn_state_machine" "codebuild" {
       RunCodeBuild = {
         Type     = "Task"
         Resource = "arn:${data.aws_partition.current.partition}:states:::codebuild:startBuild.sync"
-        # build_timeout (15 min) plus provisioning margin: a stuck
+        # build_timeout (10 min = 600s) + 300s queue/provisioning + margin: a stuck
         # startBuild.sync times the state out into the Catch -> FinalizeResult
         # path instead of hanging the workflow forever.
         TimeoutSeconds = 1200

--- a/infra/02-deploy/step_functions.tf
+++ b/infra/02-deploy/step_functions.tf
@@ -61,6 +61,10 @@ resource "aws_sfn_state_machine" "codebuild" {
       RunCodeBuild = {
         Type     = "Task"
         Resource = "arn:${data.aws_partition.current.partition}:states:::codebuild:startBuild.sync"
+        # build_timeout (15 min) plus provisioning margin: a stuck
+        # startBuild.sync times the state out into the Catch -> FinalizeResult
+        # path instead of hanging the workflow forever.
+        TimeoutSeconds = 1200
         Parameters = {
           ProjectName = aws_codebuild_project.worker.name
           EnvironmentVariablesOverride = [


### PR DESCRIPTION
Companion to jiffy-rewrite-2026#111 (presign rip-out). The engine's CodeBuild target now runs Docker workloads and is bounded against the platform's 900s watch:

- privileged_mode = true (mirrors .original's default; the srcfile path delegates docker builds here)
- build_timeout = 10 min + queued_timeout = 5 min (queued 300s + build 600s = the 900s watch; provisioning-phase ambiguity documented honestly)
- Step Functions RunCodeBuild TimeoutSeconds = 1200 wall-clock backstop routing into the existing Catch -> FinalizeResult path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141Fp1wrK27A3FcsdeeFcQn