### PR TITLE
deadline watch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,10 @@ Keep these high-value invariants in mind when changing the engine:
 
 - `aws_exe_sys` is a generic AWS-native execution helper with three Lambda entry points: `init_job`, `worker`,
   and `finalizer`.
-- Preserve the seven-field `SimplePayload` caller contract and the existing Lambda dispatch path.
+- Preserve the eight-field `SimplePayload` caller contract and the existing Lambda dispatch path.
 - `lambda` dispatch asynchronously invokes `AWS_EXE_SYS_WORKER_LAMBDA`; `codebuild` dispatch asynchronously
   starts `AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN`.
-- The Standard CodeBuild workflow passes all seven payload fields as plain-string CodeBuild environment
+- The Standard CodeBuild workflow passes all eight payload fields as plain-string CodeBuild environment
   overrides, waits for a terminal build state, and invokes the finalizer.
 - `done_endpoint` is the only caller completion marker. The worker is the primary result writer; the finalizer
   only creates a missing failed fallback with `If-None-Match: *` and propagates non-precondition S3 errors.

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -1,12 +1,12 @@
 # AWS execution engine wire contract
 
-Version: 3.0
+Version: 4.0
 
 `aws_exe_sys` is a generic command runner. It accepts a prepared command payload,
 executes it on a selected target (`lambda` or `codebuild`), and uses one S3 `ExecutionResult` object as the
 terminal marker.
 
-Version 3.0 removes the unused `ssm` execution target. The payload still contains exactly seven fields.
+Version 4.0 adds the required `timeout_seconds` field. The payload contains exactly eight fields.
 
 ## Submission
 
@@ -21,6 +21,7 @@ A caller submits the flat JSON payload below to `init_job` (Lambda, SNS, or dire
 | `commands_b64` | Required. Base64-encoded JSON array of shell commands. |
 | `done_endpoint` | Required. S3 URI where the result marker is written. |
 | `execution_target` | Required. One of `lambda` or `codebuild`. |
+| `timeout_seconds` | Required. Positive integer: the execution's overall timeout in seconds. No default; a missing or invalid value fails validation. |
 
 Here, `sops_type="ssm"` means that the SOPS age key is stored in AWS Systems Manager Parameter Store. It is independent of the removed SSM execution target.
 
@@ -39,8 +40,12 @@ Acknowledgement on dispatch:
 
 - `lambda`: asynchronous invocation of `AWS_EXE_SYS_WORKER_LAMBDA`.
 - `codebuild`: asynchronous start of the Standard workflow in `AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN`.
-  The workflow starts the managed CodeBuild project with all seven fields as plain-string CodeBuild
-  environment overrides, waits for a terminal build state, and invokes the finalizer.
+  The workflow starts the managed CodeBuild project with all eight fields as plain-string CodeBuild
+  environment overrides, waits for a terminal build state, and invokes the finalizer. The dispatcher derives
+  two numeric workflow inputs from `timeout_seconds`: the per-build CodeBuild `TimeoutInMinutesOverride`
+  (ceil to minutes plus a small margin) and the Step Functions state timeout (`timeout_seconds` plus the
+  queued bound and a provisioning margin). The CodeBuild project's static `build_timeout` is only a generous
+  ceiling the per-build override stays under.
 
 The payload is passed as plain string values to each target. Successful `init_job` acknowledgement for
 CodeBuild means Step Functions accepted the execution; it does not mean the build completed.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,7 +11,25 @@ tasks:
       - docker build -f docker/Dockerfile.test -t aws-execution-engine-test:latest .
       - docker run --rm aws-execution-engine-test:latest
 
+  test:integration:
+    desc: >-
+      Run the integration suite (mocked AWS SDK) in the same Dockerfile.test
+      harness, overriding the unit-only default CMD.
+    cmds:
+      - docker build -f docker/Dockerfile.test -t aws-execution-engine-test:latest .
+      - docker run --rm aws-execution-engine-test:latest tests/integration/ -v
+
   check:tf:
     desc: Terraform formatting check for the infra trees (no init, no apply).
     cmds:
       - tofu fmt -recursive -check infra/
+
+  check:tf:validate:
+    desc: >-
+      Terraform validation for the infra trees. Backendless init (no state,
+      no apply) then tofu validate per tree.
+    cmds:
+      - tofu -chdir=infra/00-bootstrap init -backend=false -input=false > /dev/null
+      - tofu -chdir=infra/00-bootstrap validate
+      - tofu -chdir=infra/02-deploy init -backend=false -input=false > /dev/null
+      - tofu -chdir=infra/02-deploy validate

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,17 @@
+version: "3"
+
+# Component Taskfile for the aws-execution-engine repo. Mirrors what the
+# Woodpecker pipeline runs: build the Dockerfile.test image (which lints with
+# ruff and copies the contract-drift inputs) and run the unit suite.
+
+tasks:
+  test:
+    desc: Build the Dockerfile.test image and run the unit tests.
+    cmds:
+      - docker build -f docker/Dockerfile.test -t aws-execution-engine-test:latest .
+      - docker run --rm aws-execution-engine-test:latest
+
+  check:tf:
+    desc: Terraform formatting check for the infra trees (no init, no apply).
+    cmds:
+      - tofu fmt -recursive -check infra/

--- a/aws_exe_sys/common/payload.py
+++ b/aws_exe_sys/common/payload.py
@@ -28,6 +28,8 @@ class SimplePayload:
         commands_b64:     Base64-encoded JSON array of shell commands.
         done_endpoint:    S3 URI where the result should be written.
         execution_target: One of "lambda" or "codebuild".
+        timeout_seconds:  The execution's overall timeout in seconds. Required
+                          and must be a positive integer — there is no default.
     """
 
     trigger_id: str
@@ -37,6 +39,7 @@ class SimplePayload:
     commands_b64: str
     done_endpoint: str
     execution_target: str
+    timeout_seconds: int
 
     @staticmethod
     def _coerce_null(value: object) -> str | None:
@@ -55,6 +58,25 @@ class SimplePayload:
             return None
         return value  # type: ignore[return-value]
 
+    @staticmethod
+    def _coerce_int(value: object) -> int:
+        """Coerce timeout_seconds from its transport shapes to an int.
+
+        The dispatcher serialises fields to strings for the CodeBuild env
+        transport, so a JSON int may arrive as ``"3600"``. Anything absent or
+        non-numeric collapses to 0, which validate() rejects — the field is
+        required with no default.
+        """
+        if isinstance(value, bool):
+            return 0
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped.lstrip("-").isdigit():
+                return int(stripped)
+        return 0
+
     @classmethod
     def from_dict(cls, data: dict) -> SimplePayload:
         return cls(
@@ -65,6 +87,7 @@ class SimplePayload:
             commands_b64=data.get("commands_b64", ""),
             done_endpoint=data.get("done_endpoint", ""),
             execution_target=data.get("execution_target", ""),
+            timeout_seconds=cls._coerce_int(data.get("timeout_seconds")),
         )
 
     def validate(self) -> None:
@@ -107,6 +130,11 @@ class SimplePayload:
         if self.execution_target not in _VALID_EXECUTION_TARGETS:
             errors.append(
                 f"execution_target must be one of {sorted(_VALID_EXECUTION_TARGETS)}, got {self.execution_target!r}"
+            )
+
+        if not isinstance(self.timeout_seconds, int) or isinstance(self.timeout_seconds, bool) or self.timeout_seconds <= 0:
+            errors.append(
+                f"timeout_seconds must be a positive integer, got {self.timeout_seconds!r}"
             )
 
         if errors:

--- a/aws_exe_sys/common/payload.py
+++ b/aws_exe_sys/common/payload.py
@@ -29,7 +29,7 @@ class SimplePayload:
         done_endpoint:    S3 URI where the result should be written.
         execution_target: One of "lambda" or "codebuild".
         timeout_seconds:  The execution's overall timeout in seconds. Required
-                          and must be a positive integer — there is no default.
+                          and must be a positive integer - there is no default.
     """
 
     trigger_id: str
@@ -64,7 +64,7 @@ class SimplePayload:
 
         The dispatcher serialises fields to strings for the CodeBuild env
         transport, so a JSON int may arrive as ``"3600"``. Anything absent or
-        non-numeric collapses to 0, which validate() rejects — the field is
+        non-numeric collapses to 0, which validate() rejects - the field is
         required with no default.
         """
         if isinstance(value, bool):

--- a/aws_exe_sys/init_job/dispatcher.py
+++ b/aws_exe_sys/init_job/dispatcher.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import math
 import os
 import uuid
 
@@ -19,7 +20,18 @@ _PAYLOAD_FIELDS = (
     "commands_b64",
     "done_endpoint",
     "execution_target",
+    "timeout_seconds",
 )
+
+# Margin added on top of timeout_seconds for the per-build CodeBuild override
+# (ceil to minutes), so CodeBuild's own clock never cuts the work short of the
+# caller's timeout.
+_CODEBUILD_TIMEOUT_MARGIN_MINUTES = 3
+
+# The CodeBuild QUEUED phase bound (queued_timeout = 5 min) plus a margin for
+# provisioning: added on top of timeout_seconds for the Step Functions state
+# timeout, the wall-clock backstop over the whole startBuild.sync task.
+_SFN_TIMEOUT_MARGIN_SECONDS = 300 + 300
 
 
 def _payload_to_dict(payload: SimplePayload) -> dict[str, str]:
@@ -28,7 +40,7 @@ def _payload_to_dict(payload: SimplePayload) -> dict[str, str]:
 
 
 def dispatch_to_lambda(payload: SimplePayload) -> dict:
-    """Invoke the worker Lambda with all 7 payload fields."""
+    """Invoke the worker Lambda with all 8 payload fields."""
     function_name = os.environ["AWS_EXE_SYS_WORKER_LAMBDA"]
     client = boto3.client("lambda")
 
@@ -50,10 +62,20 @@ def dispatch_to_codebuild(payload: SimplePayload) -> dict:
     client = boto3.client("stepfunctions")
     execution_name = f"aws-exe-{uuid.uuid4().hex}"
 
+    # The 8 payload fields ride as strings (CodeBuild env transport). The two
+    # derived numeric fields are computed here because the state machine's
+    # JSONPath cannot do arithmetic: the per-build CodeBuild timeout override
+    # and the Step Functions state timeout both follow timeout_seconds.
+    sfn_input: dict[str, object] = dict(_payload_to_dict(payload))
+    sfn_input["build_timeout_minutes"] = (
+        math.ceil(payload.timeout_seconds / 60) + _CODEBUILD_TIMEOUT_MARGIN_MINUTES
+    )
+    sfn_input["sfn_timeout_seconds"] = payload.timeout_seconds + _SFN_TIMEOUT_MARGIN_SECONDS
+
     response = client.start_execution(
         stateMachineArn=state_machine_arn,
         name=execution_name,
-        input=json.dumps(_payload_to_dict(payload)),
+        input=json.dumps(sfn_input),
     )
     logger.info(
         "Dispatched CodeBuild workflow",

--- a/aws_exe_sys/worker/entrypoint.sh
+++ b/aws_exe_sys/worker/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# CodeBuild entrypoint — reads 8 SimplePayload fields from env vars and runs the worker.
+# CodeBuild entrypoint - reads 8 SimplePayload fields from env vars and runs the worker.
 # ENGINE_TASK_ROOT is set by the CodeBuild buildspec to wherever engine.zip was unzipped.
 # Defaults to /var/task (the Lambda runtime convention) for backward compat.
 set -euo pipefail

--- a/aws_exe_sys/worker/entrypoint.sh
+++ b/aws_exe_sys/worker/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# CodeBuild entrypoint — reads 7 SimplePayload fields from env vars and runs the worker.
+# CodeBuild entrypoint — reads 8 SimplePayload fields from env vars and runs the worker.
 # ENGINE_TASK_ROOT is set by the CodeBuild buildspec to wherever engine.zip was unzipped.
 # Defaults to /var/task (the Lambda runtime convention) for backward compat.
 set -euo pipefail

--- a/aws_exe_sys/worker/handler.py
+++ b/aws_exe_sys/worker/handler.py
@@ -89,6 +89,7 @@ if __name__ == "__main__":
         commands_b64=os.environ.get("COMMANDS_B64", ""),
         done_endpoint=os.environ.get("DONE_ENDPOINT", ""),
         execution_target=os.environ.get("EXECUTION_TARGET", ""),
+        timeout_seconds=SimplePayload._coerce_int(os.environ.get("TIMEOUT_SECONDS")),
     )
     payload.validate()
     status = run(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,7 +13,7 @@ This repository implements a minimal, provider-agnostic executor.
   - runs the command list from `commands_b64`
   - writes the detailed terminal `ExecutionResult` to `done_endpoint`
 - **CodeBuild workflow** (Standard Step Functions):
-  - starts CodeBuild with all seven payload fields as plaintext environment overrides
+  - starts CodeBuild with all eight payload fields as plaintext environment overrides
   - waits for CodeBuild to reach a terminal state
   - invokes the finalizer on both success and caught failure
 - **`finalizer`** (`aws_exe_sys.finalizer`):

--- a/infra/02-deploy/codebuild.tf
+++ b/infra/02-deploy/codebuild.tf
@@ -19,7 +19,7 @@ resource "aws_codebuild_project" "worker" {
     type = "NO_ARTIFACTS"
   }
 
-  # S3 build logs land at s3://<bucket>/codebuild/logs/<build-id>.gz — the
+  # S3 build logs land at s3://<bucket>/codebuild/logs/<build-id>.gz - the
   # path the config0_publisher log reader expects. CloudWatch logs stay on.
   dynamic "logs_config" {
     for_each = var.s3_log_bucket_name != "" ? [1] : []

--- a/infra/02-deploy/codebuild.tf
+++ b/infra/02-deploy/codebuild.tf
@@ -2,25 +2,33 @@ resource "aws_codebuild_project" "worker" {
   name         = "${local.prefix}-worker"
   service_role = aws_iam_role.codebuild.arn
 
-  # Two clocks bound the build against the platform's 900s watch from FIRE:
-  #   queued_timeout (5 min = 300s) + build_timeout (10 min = 600s) = 900s.
-  # Verified AWS semantics (CodeBuild API reference, Project type):
-  #   - queuedTimeoutInMinutes: "The number of minutes a build is allowed to
-  #     be queued before it times out." Covers the QUEUED phase only.
-  #     Minimum allowed value is 5, so 300s is the tightest enforceable bound.
-  #   - timeoutInMinutes: "How long, in minutes ... for AWS CodeBuild to wait
-  #     before timing out any related build that did not get marked as
-  #     completed." This is the post-queue build clock.
+  # The REAL per-build bound is the TimeoutInMinutesOverride the Step
+  # Functions RunCodeBuild task passes (derived from the payload's
+  # timeout_seconds plus a small margin - step_functions.tf). The static
+  # build_timeout here is only a generous ceiling that per-build overrides
+  # stay under. queued_timeout covers the QUEUED phase only (minimum 5).
   # HONEST GAP: AWS does not explicitly document which clock the PROVISIONING
-  # phase counts against. If provisioning falls outside both clocks, the
-  # 300 + 600 arithmetic is not a proof; the Step Functions TimeoutSeconds
-  # (step_functions.tf) stays the wall-clock backstop that bounds the whole
-  # startBuild.sync task, provisioning included.
-  build_timeout  = 10
+  # phase counts against; the Step Functions state timeout
+  # (sfn_timeout_seconds = timeout_seconds + queued bound + margin) stays the
+  # wall-clock backstop that bounds the whole startBuild.sync task,
+  # provisioning included.
+  build_timeout  = 480
   queued_timeout = 5
 
   artifacts {
     type = "NO_ARTIFACTS"
+  }
+
+  # S3 build logs land at s3://<bucket>/codebuild/logs/<build-id>.gz — the
+  # path the config0_publisher log reader expects. CloudWatch logs stay on.
+  dynamic "logs_config" {
+    for_each = var.s3_log_bucket_name != "" ? [1] : []
+    content {
+      s3_logs {
+        status   = "ENABLED"
+        location = "${var.s3_log_bucket_name}/codebuild/logs"
+      }
+    }
   }
 
   environment {

--- a/infra/02-deploy/iam.tf
+++ b/infra/02-deploy/iam.tf
@@ -210,7 +210,7 @@ resource "aws_iam_role_policy" "codebuild" {
         Resource = concat(
           ["${aws_s3_bucket.done.arn}/*"],
           [for arn in var.additional_result_bucket_arns : "${arn}/*"],
-          # S3 build logs (codebuild.tf logs_config) — grant only the exact
+          # S3 build logs (codebuild.tf logs_config) - grant only the exact
           # codebuild/logs/ prefix when a log bucket is configured.
           var.s3_log_bucket_name != "" ? ["arn:aws:s3:::${var.s3_log_bucket_name}/codebuild/logs/*"] : [],
         )

--- a/infra/02-deploy/iam.tf
+++ b/infra/02-deploy/iam.tf
@@ -210,6 +210,9 @@ resource "aws_iam_role_policy" "codebuild" {
         Resource = concat(
           ["${aws_s3_bucket.done.arn}/*"],
           [for arn in var.additional_result_bucket_arns : "${arn}/*"],
+          # S3 build logs (codebuild.tf logs_config) — grant only the exact
+          # codebuild/logs/ prefix when a log bucket is configured.
+          var.s3_log_bucket_name != "" ? ["arn:aws:s3:::${var.s3_log_bucket_name}/codebuild/logs/*"] : [],
         )
       },
       {

--- a/infra/02-deploy/step_functions.tf
+++ b/infra/02-deploy/step_functions.tf
@@ -61,15 +61,20 @@ resource "aws_sfn_state_machine" "codebuild" {
       RunCodeBuild = {
         Type     = "Task"
         Resource = "arn:${data.aws_partition.current.partition}:states:::codebuild:startBuild.sync"
-        # queued_timeout (5 min = 300s) + build_timeout (10 min = 600s) + 300s
-        # margin: this is the WALL-CLOCK backstop over the whole
-        # startBuild.sync task - it also covers the PROVISIONING phase, which
-        # AWS does not explicitly assign to either CodeBuild clock
-        # (codebuild.tf). A stuck build times the state out into the
+        # Deadline-driven wall-clock backstop over the whole startBuild.sync
+        # task: the dispatcher computes sfn_timeout_seconds =
+        # timeout_seconds + queued bound (300s) + provisioning margin (300s)
+        # and passes it in the execution input - the PROVISIONING phase is not
+        # explicitly assigned to either CodeBuild clock, so the margin covers
+        # it. A stuck build times the state out into the
         # Catch -> FinalizeResult path instead of hanging the workflow forever.
-        TimeoutSeconds = 1200
+        TimeoutSecondsPath = "$.sfn_timeout_seconds"
         Parameters = {
           ProjectName = aws_codebuild_project.worker.name
+          # Per-build override derived from timeout_seconds + margin (ceil to
+          # minutes) by the dispatcher; the project's static build_timeout is
+          # only a generous ceiling the override stays under.
+          "TimeoutInMinutesOverride.$" = "$.build_timeout_minutes"
           EnvironmentVariablesOverride = [
             {
               Name      = "TRIGGER_ID"
@@ -104,6 +109,11 @@ resource "aws_sfn_state_machine" "codebuild" {
             {
               Name      = "EXECUTION_TARGET"
               "Value.$" = "$.execution_target"
+              Type      = "PLAINTEXT"
+            },
+            {
+              Name      = "TIMEOUT_SECONDS"
+              "Value.$" = "$.timeout_seconds"
               Type      = "PLAINTEXT"
             },
           ]

--- a/infra/02-deploy/variables.tf
+++ b/infra/02-deploy/variables.tf
@@ -61,6 +61,12 @@ variable "additional_package_bucket_arns" {
   }
 }
 
+variable "s3_log_bucket_name" {
+  description = "S3 bucket for CodeBuild build logs (written under codebuild/logs/). Empty disables S3 logs."
+  type        = string
+  default     = ""
+}
+
 variable "additional_result_bucket_arns" {
   description = "Additional S3 bucket ARNs to which workers may write terminal results."
   type        = list(string)

--- a/tests/integration/test_simplified_init.py
+++ b/tests/integration/test_simplified_init.py
@@ -18,7 +18,7 @@ def _b64_cmds(cmds: list[str]) -> str:
 
 
 def _valid_event(**overrides) -> dict:
-    """Build a valid direct-invoke event dict with all 7 fields."""
+    """Build a valid direct-invoke event dict with all 8 fields."""
     defaults = {
         "trigger_id": "trg-int-001",
         "s3_package_uri": "s3://test-bucket/exec/trg-int-001/exec.zip",
@@ -27,6 +27,7 @@ def _valid_event(**overrides) -> dict:
         "commands_b64": _b64_cmds(["echo hello"]),
         "done_endpoint": "s3://done-bucket/trg-int-001/result.json",
         "execution_target": "lambda",
+        "timeout_seconds": 3600,
     }
     defaults.update(overrides)
     return defaults

--- a/tests/integration/test_simplified_init.py
+++ b/tests/integration/test_simplified_init.py
@@ -76,7 +76,7 @@ class TestInitValidPayloadDispatch:
         assert call_kwargs["InvocationType"] == "Event"
         sent = json.loads(call_kwargs["Payload"].decode())
         assert sent["trigger_id"] == "trg-int-001"
-        assert len(sent) == 7
+        assert len(sent) == 8
 
     def test_dispatch_to_codebuild(self, monkeypatch):
         state_machine_arn = "arn:aws:states:us-east-1:123:stateMachine:xe"
@@ -105,8 +105,17 @@ class TestInitValidPayloadDispatch:
         call_kwargs = mock_stepfunctions.start_execution.call_args.kwargs
         assert call_kwargs["stateMachineArn"] == state_machine_arn
         sent = json.loads(call_kwargs["input"])
-        assert set(sent) == set(_valid_event())
-        assert all(isinstance(value, str) for value in sent.values())
+        # The SFN input is the 8 SimplePayload fields plus the two derived
+        # timeout fields the state machine consumes.
+        assert set(sent) == set(_valid_event()) | {
+            "build_timeout_minutes",
+            "sfn_timeout_seconds",
+        }
+        assert all(
+            isinstance(sent[field], str) for field in _valid_event()
+        )
+        assert isinstance(sent["build_timeout_minutes"], int)
+        assert isinstance(sent["sfn_timeout_seconds"], int)
         mock_stepfunctions.start_build.assert_not_called()
 
 

--- a/tests/integration/test_worker_simplified.py
+++ b/tests/integration/test_worker_simplified.py
@@ -28,7 +28,7 @@ def _b64_cmds(cmds: list[str]) -> str:
 
 
 def _valid_event(**overrides) -> dict:
-    """Build a valid direct-invoke event dict with all 7 fields."""
+    """Build a valid direct-invoke event dict with all 8 fields."""
     defaults = {
         "trigger_id": "trg-wkr-001",
         "s3_package_uri": "s3://test-bucket/exec/trg-wkr-001/exec.zip",
@@ -37,6 +37,7 @@ def _valid_event(**overrides) -> dict:
         "commands_b64": _b64_cmds(["echo hello"]),
         "done_endpoint": "s3://done-bucket/trg-wkr-001/result.json",
         "execution_target": "lambda",
+        "timeout_seconds": 3600,
     }
     defaults.update(overrides)
     return defaults

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -28,13 +28,14 @@ def _valid_payload(**overrides) -> SimplePayload:
         "commands_b64": _b64_cmds(["echo hello"]),
         "done_endpoint": "s3://done-bucket/trg-001/result.json",
         "execution_target": "lambda",
+        "timeout_seconds": 3600,
     }
     defaults.update(overrides)
     return SimplePayload(**defaults)
 
 
 class TestPayloadToDict:
-    def test_all_7_fields_present(self):
+    def test_all_8_fields_present(self):
         payload = _valid_payload()
         d = _payload_to_dict(payload)
         assert set(d.keys()) == {
@@ -45,8 +46,10 @@ class TestPayloadToDict:
             "commands_b64",
             "done_endpoint",
             "execution_target",
+            "timeout_seconds",
         }
         assert d["trigger_id"] == "trg-001"
+        assert d["timeout_seconds"] == "3600"
         assert d["sops_type"] == "ssm"
 
     def test_none_values_become_empty_string(self):
@@ -73,7 +76,7 @@ class TestDispatchToLambda:
         mock_client.invoke.assert_called_once()
 
     @patch("aws_exe_sys.init_job.dispatcher.boto3")
-    def test_passes_all_7_fields_in_payload(self, mock_boto3, monkeypatch):
+    def test_passes_all_8_fields_in_payload(self, mock_boto3, monkeypatch):
         monkeypatch.setenv("AWS_EXE_SYS_WORKER_LAMBDA", "my-worker-fn")
 
         mock_client = MagicMock()
@@ -95,7 +98,8 @@ class TestDispatchToLambda:
         assert sent_payload["done_endpoint"] == "s3://done-bucket/trg-001/result.json"
         assert sent_payload["execution_target"] == "lambda"
         assert sent_payload["commands_b64"] == payload.commands_b64
-        assert len(sent_payload) == 7
+        assert sent_payload["timeout_seconds"] == "3600"
+        assert len(sent_payload) == 8
 
 
 class TestDispatchToCodeBuild:
@@ -119,7 +123,7 @@ class TestDispatchToCodeBuild:
 
     @patch("aws_exe_sys.init_job.dispatcher.uuid.uuid4")
     @patch("aws_exe_sys.init_job.dispatcher.boto3")
-    def test_passes_exactly_7_plain_string_fields(self, mock_boto3, mock_uuid4, monkeypatch):
+    def test_passes_8_plain_string_fields_plus_derived_timeouts(self, mock_boto3, mock_uuid4, monkeypatch):
         state_machine_arn = "arn:aws:states:us-east-1:123:stateMachine:xe"
         monkeypatch.setenv("AWS_EXE_SYS_CODEBUILD_STATE_MACHINE_ARN", state_machine_arn)
         mock_uuid4.return_value.hex = "unique123"
@@ -143,10 +147,19 @@ class TestDispatchToCodeBuild:
             "commands_b64",
             "done_endpoint",
             "execution_target",
+            "timeout_seconds",
+            "build_timeout_minutes",
+            "sfn_timeout_seconds",
         }
-        assert all(isinstance(value, str) for value in sent_payload.values())
+        payload_fields = {k: v for k, v in sent_payload.items()
+                          if k not in ("build_timeout_minutes", "sfn_timeout_seconds")}
+        assert all(isinstance(value, str) for value in payload_fields.values())
         assert sent_payload["sops_type"] == ""
         assert sent_payload["sops_path"] == ""
+        # Derived numeric workflow inputs follow timeout_seconds:
+        # ceil(3600/60) + 3 margin minutes; 3600 + 300 queued + 300 margin.
+        assert sent_payload["build_timeout_minutes"] == 63
+        assert sent_payload["sfn_timeout_seconds"] == 4200
 
     @patch("aws_exe_sys.init_job.dispatcher.boto3")
     def test_missing_state_machine_configuration_fails_loudly(self, mock_boto3, monkeypatch):

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -20,6 +20,7 @@ def _valid_payload_dict(**overrides) -> dict:
         "commands_b64": _b64_cmds(["echo hello"]),
         "done_endpoint": "s3://done-bucket/trg-001/result.json",
         "execution_target": "lambda",
+        "timeout_seconds": 3600,
     }
     defaults.update(overrides)
     return defaults

--- a/tests/unit/test_payload.py
+++ b/tests/unit/test_payload.py
@@ -23,6 +23,7 @@ def _valid_payload(**overrides) -> SimplePayload:
         "commands_b64": _b64_cmds(["echo hello"]),
         "done_endpoint": "s3://done-bucket/trg-001/result.json",
         "execution_target": "lambda",
+        "timeout_seconds": 3600,
     }
     defaults.update(overrides)
     return SimplePayload(**defaults)
@@ -57,6 +58,7 @@ class TestSimplePayloadFromDict:
             "commands_b64": _b64_cmds(["ls"]),
             "done_endpoint": "s3://done/result",
             "execution_target": "codebuild",
+        "timeout_seconds": 3600,
         }
         p = SimplePayload.from_dict(data)
         assert p.trigger_id == "t-99"
@@ -112,6 +114,7 @@ def _dict_with(**overrides) -> dict:
         "commands_b64": _b64_cmds(["echo hello"]),
         "done_endpoint": "s3://done-bucket/trg-001/result.json",
         "execution_target": "lambda",
+        "timeout_seconds": 3600,
     }
     data.update(overrides)
     return data

--- a/tests/unit/test_step_functions_terraform.py
+++ b/tests/unit/test_step_functions_terraform.py
@@ -15,7 +15,7 @@ def test_state_machine_uses_standard_sync_codebuild_and_finalizer():
     assert "IfNoneMatch" not in source
 
 
-def test_state_machine_passes_exactly_seven_plaintext_environment_overrides():
+def test_state_machine_passes_exactly_eight_plaintext_environment_overrides():
     source = STATE_MACHINE_TERRAFORM.read_text()
 
     expected_names = {
@@ -26,7 +26,18 @@ def test_state_machine_passes_exactly_seven_plaintext_environment_overrides():
         "COMMANDS_B64",
         "DONE_ENDPOINT",
         "EXECUTION_TARGET",
+        "TIMEOUT_SECONDS",
     }
     for name in expected_names:
         assert source.count(f'Name      = "{name}"') == 1
-    assert source.count('Type      = "PLAINTEXT"') == 7
+    assert source.count('Type      = "PLAINTEXT"') == 8
+
+
+def test_state_machine_timeouts_derive_from_timeout_seconds():
+    source = STATE_MACHINE_TERRAFORM.read_text()
+
+    # The state timeout and the per-build CodeBuild override both follow the
+    # dispatcher-computed deadline inputs, not static constants.
+    assert 'TimeoutSecondsPath = "$.sfn_timeout_seconds"' in source
+    assert '"TimeoutInMinutesOverride.$" = "$.build_timeout_minutes"' in source
+    assert "TimeoutSeconds = 1200" not in source

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -31,6 +31,7 @@ def _valid_payload(**overrides) -> SimplePayload:
         "commands_b64": _b64_cmds(["echo hello"]),
         "done_endpoint": "s3://done-bucket/trg-001/result.json",
         "execution_target": "lambda",
+        "timeout_seconds": 3600,
     }
     defaults.update(overrides)
     return SimplePayload(**defaults)


### PR DESCRIPTION
- **add component Taskfile: test (Dockerfile.test) and check:tf**
- **SimplePayload: add required timeout_seconds 8th field; deadline-driven CodeBuild timeouts**
- **codebuild: optional S3 build logs at codebuild/logs/ plus scoped PutObject grant**
- **style: replace branch-introduced U+2014 em dashes with plain dashes**
- **test+task: run the integration suite and tofu validate through task targets**
